### PR TITLE
Stacker: ingest + emit every pabgb the source mod ships (catch-all)

### DIFF
--- a/CrimsonGameMods/gui/tabs/stacker.py
+++ b/CrimsonGameMods/gui/tabs/stacker.py
@@ -247,6 +247,13 @@ class ModEntry:
     # "equipslotinfo.pabgh". Values are raw bytes.
     staged_skill_files: dict = field(default_factory=dict)
     staged_equip_files: dict = field(default_factory=dict)
+    # Catch-all bucket for every other .pabgb/.pabgh pair the source mod
+    # ships (buff_info, condition_info, gimmick_info, store_info, etc.).
+    # Pre-1.1.5 these were dropped at folder_paz ingestion (only the four
+    # equipslot+skill names were extracted), making any mod that touched
+    # other tables silently broken in the Stacker pipeline. The Field
+    # JSON exporter consumes this via _merged_other_files.
+    staged_other_files: dict = field(default_factory=dict)
     # Legacy-JSON-only: per-patch field attribution + merge strategy. See
     # iteminfo_inspector.py. `merge_mode` is "strict" (default — apply
     # bytes to vanilla then re-parse) or "semantic" (skip byte apply,
@@ -2327,18 +2334,47 @@ class StackerTab(QWidget):
                     except Exception:
                         items, _ = _parse_with_fallback(crimson_rs, game, raw)
                     m.parsed_items = items
-                    # Pull companion sibling files if this mod ships with
-                    # them (UP mods package equipslotinfo; passive-skill
-                    # mods package skill.pabgb). Silently ignored when
-                    # the PAZ doesn't contain them — most iteminfo mods
-                    # don't.
+                    # Pull every .pabgb/.pabgh sibling this mod ships.
+                    # Pre-1.1.5 only the four hardcoded equipslotinfo +
+                    # skill names made it through here; mods that
+                    # touched buff_info / condition_info / gimmick_info
+                    # / store_info / etc. silently lost those bytes at
+                    # this layer. Now we enumerate the PAMT directly so
+                    # any pabgb table the modder ships gets picked up.
+                    #
+                    # Routing:
+                    #   equipslotinfo.* → staged_equip_files (registry)
+                    #   skill.*         → staged_skill_files (registry, disabled)
+                    #   anything else   → staged_other_files (catch-all blob diff)
                     companions = []
-                    for fname, target in (
-                        ("equipslotinfo.pabgb", "staged_equip_files"),
-                        ("equipslotinfo.pabgh", "staged_equip_files"),
-                        ("skill.pabgb", "staged_skill_files"),
-                        ("skill.pabgh", "staged_skill_files"),
-                    ):
+                    discovered: list[str] = []
+                    try:
+                        pamt_path = os.path.join(m.path, m.group, "0.pamt")
+                        with open(pamt_path, 'rb') as _pf:
+                            pamt_data = _pf.read()
+                        pamt = crimson_rs.parse_pamt_bytes(pamt_data)
+                        for d in pamt.get('directories', []):
+                            if d.get('path') != INTERNAL_DIR:
+                                continue
+                            for f in d.get('files', []):
+                                fname = f.get('name', '')
+                                # Iteminfo flows through the dict-list
+                                # merge path, not Bucket D.
+                                if fname == ITEMINFO_PABGB or fname == ITEMINFO_PABGH:
+                                    continue
+                                if fname.endswith('.pabgb') or fname.endswith('.pabgh'):
+                                    discovered.append(fname)
+                    except Exception:
+                        # PAMT parse failed — fall back to the legacy
+                        # four hardcoded names so equipslotinfo + skill
+                        # mods still work even if the PAMT decoder hits
+                        # an edge case.
+                        discovered = [
+                            "equipslotinfo.pabgb", "equipslotinfo.pabgh",
+                            "skill.pabgb", "skill.pabgh",
+                        ]
+
+                    for fname in discovered:
                         try:
                             comp_raw = bytes(crimson_rs.extract_file(
                                 m.path, m.group, INTERNAL_DIR, fname))
@@ -2346,7 +2382,12 @@ class StackerTab(QWidget):
                             continue
                         if not comp_raw:
                             continue
-                        getattr(m, target)[fname] = comp_raw
+                        if fname.startswith("equipslotinfo."):
+                            m.staged_equip_files[fname] = comp_raw
+                        elif fname.startswith("skill."):
+                            m.staged_skill_files[fname] = comp_raw
+                        else:
+                            m.staged_other_files[fname] = comp_raw
                         companions.append(fname)
                     m.apply_stats = (
                         f"compiled PAZ unpacked"
@@ -2936,18 +2977,19 @@ class StackerTab(QWidget):
     def _collect_bucket_d(self, ok_mods: list) -> dict:
         """Gather staged sibling files from all sources.
 
-        Returns a dict of {filename_within_INTERNAL_DIR: bytes}. Files
-        recognized: skill.pabgb, skill.pabgh, equipslotinfo.pabgb,
-        equipslotinfo.pabgh. Last source wins if two contribute the
-        same filename.
+        Returns a dict of {filename_within_INTERNAL_DIR: bytes}. As of
+        1.1.5 every .pabgb/.pabgh pair the source mod ships is in
+        scope — pre-1.1.5 only skill.* and equipslotinfo.* were
+        recognized. Last source wins if two contribute the same
+        filename.
 
         Sources contributing sibling files:
         - itembuffs_edits (Pull from ItemBuffs): staged by UP v2 /
           passive-skill injection / imbue whitelisting.
-        - folder_paz (external mods): captured at parse time when the
-          mod's PAZ ships equipslotinfo/skill alongside iteminfo.
-          Covers community mods like "UP fork by X" or "passive skill
-          pack" that bundle both files.
+        - folder_paz (external mods): every pabgb pair in the mod's
+          PAZ now flows through. Equipslotinfo + skill go to their
+          dedicated buckets; everything else lands in
+          staged_other_files for the catch-all blob diff.
         """
         collected: dict = {}
         conflicts: list[tuple] = []
@@ -2956,7 +2998,9 @@ class StackerTab(QWidget):
             # files now; loose_pabgb / legacy_json never do.
             if m.kind not in ("itembuffs_edits", "folder_paz"):
                 continue
-            for bucket in (m.staged_skill_files, m.staged_equip_files):
+            for bucket in (m.staged_skill_files,
+                           m.staged_equip_files,
+                           m.staged_other_files):
                 for fname, data in bucket.items():
                     if fname in collected and collected[fname] != data:
                         conflicts.append((fname, m.name))
@@ -3768,6 +3812,60 @@ class StackerTab(QWidget):
                     self._log_line(
                         f"  + {len(target_intents)} {entry['label']} "
                         f"intent(s)")
+
+        # ── Catch-all: every .pabgb/.pabgh pair in _merged_other_files
+        # that no registry entry already handled. Uses the generic
+        # blob-table diff (key/string_key/is_blocked + per-record
+        # _blob_b64). DMM 1.3.3+'s apply_v3_to_blob_table_body consumes
+        # this shape directly. Field-level intents for typed-prefix
+        # tables would need per-table parser dispatch on the dmm-parser
+        # side — that's a follow-up. For now, this unblocks every mod
+        # that touches buff_info / condition_info / gimmick_info /
+        # store_info / etc. so their edits actually ship.
+        if crimson_rs is not None:
+            other_snap = getattr(self, "_merged_other_files", None) or {}
+            handled_targets = {e['name'] for e in _FIELD_JSON_TARGET_REGISTRY}
+            pabgb_names = sorted(
+                n for n in other_snap if n.endswith(".pabgb"))
+            for pabgb_name in pabgb_names:
+                if pabgb_name in handled_targets:
+                    # Registry already covered it
+                    continue
+                pabgh_name = pabgb_name[:-len(".pabgb")] + ".pabgh"
+                if pabgh_name not in other_snap:
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} skipped: no sister "
+                        f"{pabgh_name} in mod stack")
+                    continue
+                if not self._game_path:
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} catch-all skipped: "
+                        f"game path not set")
+                    continue
+                try:
+                    vanilla_pabgb = bytes(crimson_rs.extract_file(
+                        self._game_path, '0008',
+                        INTERNAL_DIR, pabgb_name))
+                    vanilla_pabgh = bytes(crimson_rs.extract_file(
+                        self._game_path, '0008',
+                        INTERNAL_DIR, pabgh_name))
+                    t_intents = _diff_blob_table_to_intents(
+                        vanilla_pabgh, vanilla_pabgb,
+                        other_snap[pabgh_name],
+                        other_snap[pabgb_name],
+                        pabgb_name)
+                except Exception as e:
+                    # Don't block the export — iteminfo + registry
+                    # targets already gathered are still valid.
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} catch-all diff failed: {e}"
+                        f" — export will skip this target")
+                    continue
+                if t_intents:
+                    extra_targets.append((pabgb_name, t_intents))
+                    self._log_line(
+                        f"  + {len(t_intents)} {pabgb_name} "
+                        f"intent(s) (generic blob diff)")
 
         if not intents and not extra_targets:
             QMessageBox.information(self, "Export Field JSON",


### PR DESCRIPTION
## Problem

Pre-1.1.5 Stacker silently dropped every pabgb table that wasn't iteminfo, equipslotinfo, or skill. PR #49 fixed the **export** half for equipslotinfo (multi-target Field JSON v3), but the **ingestion** half is still hardcoded — and there are TWO more layers downstream that also assume the same three-table allow-list.

A folder mod that ships, e.g., \`buff_info.pabgb\` + \`buff_info.pabgh\`, never gets those bytes through to the Stacker pipeline. They're dropped at \`_run_inner\`'s hardcoded four-name companion list before the merge ever runs. So the merge has nothing, the bucket collector skips them, the export emits nothing, the user wonders why their non-iteminfo edits don't ship.

## Four-layer fix

Walks the Stacker pipeline end-to-end:

### 1. \`ModEntry\` — new bucket
\`staged_other_files: dict\` alongside the existing \`staged_skill_files\` / \`staged_equip_files\`.

### 2. \`_run_inner\` (folder_paz ingestion) — PAMT enumeration
Replaced the 4-element hardcoded allow-list with a \`crimson_rs.parse_pamt_bytes\` walk. Picks up every \`.pabgb\`/\`.pabgh\` in the mod's PAZ, routes equipslotinfo* / skill* into their dedicated buckets, everything else into \`staged_other_files\`. Falls back to the legacy four-name list if PAMT parse fails.

### 3. \`_collect_bucket_d\` — iterates 3 buckets
Was iterating only \`(skill, equip)\`; now iterates \`(skill, equip, other)\`. Conflict detection logic unchanged.

### 4. \`_export_field_json\` — catch-all consumer
After the registry walk, a new pass over \`_merged_other_files\` runs the existing \`_diff_blob_table_to_intents\` against the corresponding vanilla pair from \`0008/INTERNAL_DIR\`. Per-table failures are logged, not fatal — iteminfo + registry targets still ship even if one side-target's blob diff fails.

## Limitations / follow-up

- The catch-all uses the generic blob-table diff (\`[key u32][string_key][is_blocked u8][blob:rest]\`). For typed-prefix Tier 1.5 tables this still produces correct intents (any field change manifests as a per-record \`_blob_b64\`), but it loses field-level granularity for the typed prefix. Field-level intents per typed table needs a per-pabgb dispatch in dmm-parser exposing the existing \`to_json_dict\` / \`write_from_json_dict\` methods through Python — separate follow-up.
- \`_diff_blob_table_to_intents\` assumes u32 in-record key. Tables with u16 in-record key may parse incorrectly through the catch-all path. The per-table failure log surfaces this if it happens.

## Why this doesn't conflict with PR #47

PR #47 modifies \`CrimsonSaveEditor/*\` (separate application). This PR only touches \`CrimsonGameMods/gui/tabs/stacker.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)