### PR TITLE
Stacker: field-level catchall via dmm_parser.parse_table (122 tables)

### DIFF
--- a/CrimsonGameMods/BUILD_TEST_V3_1.md
+++ b/CrimsonGameMods/BUILD_TEST_V3_1.md
@@ -1,0 +1,225 @@
+# Building & Testing CrimsonGameMods with Field JSON v3.1 Support
+
+**Audience**: Internal testers receiving a v1.1.5-rc1 build.
+**Purpose**: Validate the Field JSON v3.1 multi-target field-level catchall before public release.
+**Spec**: See `FIELD_JSON_V3_1_SPEC.md` for the format.
+
+---
+
+## What's new in this build
+
+The Stacker tool can now produce **field-level intents** for 122 typed game-data tables
+(`gimmick_info`, `condition_info`, `drop_set_info`, `character_info`, `buff_info`, etc.)
+instead of the v1.1.4 blob-level fallback that replaced whole records.
+
+This means:
+
+- **Two mods touching different fields of the same gimmick coexist cleanly** — last-writer-wins
+  no longer eats the other mod's edits.
+- **Cross-table mods are first-class** — a weapon mod that buffs damage in `iteminfo` AND
+  tweaks a visual in `gimmick_info` AND adds a passive in `skill_info` exports as three
+  independently-mergeable target sections.
+- **Mods survive game updates** — same as v3.0, field names resolve at apply-time.
+
+---
+
+## Quick test (precompiled build)
+
+If you received `CrimsonDesktopSuite_v1.1.5-rc1.zip`:
+
+1. Unzip anywhere.
+2. Run `CrimsonGameMods.exe`.
+3. Open the **Stacker** tab.
+4. Drop two mods that both touch `gimmick_info.pabgb` (e.g. two visual-effect tweaks).
+5. Click **Export Field JSON**. You should see log lines like:
+   ```
+   + 12 gimmick_info.pabgb intent(s) (field-level diff)
+   ```
+   The `(field-level diff)` suffix confirms v3.1 is active. If you see `(blob-level diff)`,
+   `dmm_parser` wasn't bundled correctly — please report.
+6. Open the exported `.field.json` and verify:
+   - `format == 3`
+   - `format_minor == 1` (or `targets[]` array present)
+   - One `targets[]` entry per touched table
+7. Apply the exported `.field.json` via DMM 1.3.4+ and verify the game data matches what the
+   source mods would have produced.
+
+---
+
+## Building from source (developers / advanced testers)
+
+### Prerequisites
+
+```
+- Python 3.13+
+- Rust toolchain (stable) — only needed if building dmm-parser from source
+- maturin (pip install maturin)
+- The CrimsonSaveEditor/requirements.txt deps (PySide6==6.8.3, lz4, cryptography, pyinstaller, crimson_rs)
+```
+
+### Step 1: Build & install dmm-parser
+
+```bash
+git clone https://github.com/exodiaprivate-eng/dmm-parser
+cd dmm-parser
+maturin develop --release
+```
+
+Verify the install:
+```bash
+python -c "import dmm_parser; print(dmm_parser.parse_table.__doc__)"
+```
+
+You should see the `parse_table` docstring. If you see `ImportError`, the wheel didn't install
+into the current Python env — try `pip install -e .` instead, or activate the same venv
+CrimsonGameMods uses.
+
+### Step 2: Install the v3.1 extras
+
+```bash
+cd /path/to/CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS-clone/CrimsonGameMods
+pip install -r requirements_v3_1.txt
+```
+
+(This is currently a no-op since `dmm-parser` was installed in Step 1, but ensures any
+future v3.1 build deps are present.)
+
+### Step 3: Build CrimsonGameMods
+
+```bash
+python -m PyInstaller CrimsonGameMods.spec --noconfirm
+```
+
+You should see this line in the build output:
+
+```
+[v3.1] Bundling dmm_parser from C:\...\Lib\site-packages\dmm_parser
+```
+
+If you see `[v3.1] dmm_parser not installed — Stacker will fall back...`, repeat Step 1
+in the same Python environment.
+
+The exe lands at `dist/CrimsonGameMods.exe` (~85-90 MB; v3.1 build adds ~5 MB for `dmm_parser.pyd`).
+
+### Step 4: Build DMM (optional, only if testing v3.1 apply path)
+
+DMM 1.3.4+ is required for non-iteminfo target apply. If your testers will only validate
+the **export** side (Stacker → field.json), DMM 1.3.3 is fine — it'll apply the iteminfo
+target and warn-skip the others.
+
+```bash
+cd CrimsonGameMods/DMMLoader
+npm install
+npx tauri build
+# Output: src-tauri/target/release/definitive-mod-manager.exe
+```
+
+(See `BUILD_UNIFIED.md` for DMM build details.)
+
+### Step 5: Bundle for distribution
+
+```bash
+cd CrimsonGameMods
+python bundle_unified.py
+# Output: dist/CrimsonDesktopSuite/
+#         dist/CrimsonDesktopSuite_full.zip
+```
+
+Zip the result and ship to testers.
+
+---
+
+## Smoke tests for testers
+
+### Test A — Single gimmick mod (export round-trip)
+
+1. Source mod: edit `gimmick_info.pabgb` so one entry has its `cooltime` field changed.
+2. Stack with that one mod, click **Export Field JSON**.
+3. Verify the exported JSON has:
+   ```json
+   {
+     "format": 3, "format_minor": 1,
+     "targets": [
+       {
+         "file": "gimmick_info.pabgb",
+         "intents": [
+           {"entry": "...", "key": ..., "field": "cooltime", "op": "set", "new": ...}
+         ]
+       }
+     ]
+   }
+   ```
+4. **Pass**: exactly one intent emitted with the correct field path and new value.
+5. **Fail**: `_blob_b64` field in the intent (= v3.1 catchall fell back to blob-level), or
+   missing `format_minor`, or wrong `targets[]` shape.
+
+### Test B — Two-mod no-conflict stack
+
+1. Source mod A: edits `gimmick_info` entry X field `duration_ms`.
+2. Source mod B: edits `gimmick_info` entry X field `intensity` (different field, same entry).
+3. Stack both, export.
+4. Verify the exported JSON has **both intents** in the `gimmick_info.pabgb` target:
+   ```json
+   {
+     "intents": [
+       {"entry": "X", "field": "duration_ms", "op": "set", "new": ...},
+       {"entry": "X", "field": "intensity",   "op": "set", "new": ...}
+     ]
+   }
+   ```
+5. **Pass**: both intents present.
+6. **Fail**: only one intent (= last-writer ate the other = v3.0 blob-level behavior).
+
+### Test C — Cross-table stack
+
+1. Source mod: edits `iteminfo` (cooldown) AND `gimmick_info` (visual) AND `skill_info` (passive).
+2. Stack, export.
+3. Verify exported JSON has **3 entries in `targets[]`**, one per file.
+4. **Pass**: 3 target sections with correct file names and intents per table.
+5. **Fail**: missing target sections, or all intents collapsed under `iteminfo.pabgb`.
+
+### Test D — Backward compatibility
+
+1. Source mod: edits `iteminfo` ONLY (no other tables).
+2. Stack one mod, export.
+3. Verify the exported JSON uses **legacy single-target shape**:
+   ```json
+   {
+     "format": 3,
+     "target": "iteminfo.pabgb",
+     "intents": [...]
+   }
+   ```
+   (NOT `targets[]` array — single iteminfo target falls back to v3.0 shape for
+   backward compat with older DMM.)
+4. **Pass**: legacy shape, applies cleanly in DMM 1.3.3.
+5. **Fail**: `targets[]` shape used for single-target — older DMM will reject.
+
+---
+
+## Known limitations (will not pass these tests yet)
+
+- **List append/remove**: only `set` op is implemented. If a mod adds a new element to
+  `enchant_data_list`, the export will emit a whole-list `set` (replaces all levels).
+  v3.2 will introduce `list_append`/`list_remove`.
+- **Add new entry**: if a mod adds a brand-new `gimmick_info` entry not in vanilla, the
+  export skips it (v3 spec doesn't yet support `add_entry`).
+- **Cross-table references**: `"new": "@gimmick_info.X"` syntax is v3.2-only.
+- **DMM 1.3.3 and older** apply iteminfo intents and warn-skip everything else. This is
+  expected — non-iteminfo apply requires DMM 1.3.4+.
+
+---
+
+## Reporting issues
+
+Please report with:
+
+1. Build version (file → about → CrimsonGameMods version)
+2. The source mods you stacked (zip them up)
+3. The exported `.field.json` (paste or attach)
+4. The Stacker log output (right-click log → copy all)
+5. What you expected vs what happened
+
+Filing channels:
+- Discord: CrimsonGameMods #beta-testing
+- GitHub: https://github.com/NattKh/CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS/issues with `[v3.1-rc]` prefix

--- a/CrimsonGameMods/CrimsonGameMods.spec
+++ b/CrimsonGameMods/CrimsonGameMods.spec
@@ -1,12 +1,32 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+# dmm_parser is optional — bundled if installed via `pip install dmm-parser`
+# (or `maturin develop` from the dmm-parser repo). Provides Field JSON v3.1
+# multi-target field-level catchall via dmm_parser.parse_table for 122
+# typed game-data tables. See FIELD_JSON_V3_1_SPEC.md.
+import importlib.util as _ilu
+_dmm_spec = _ilu.find_spec('dmm_parser')
+_v31_extra_datas = []
+_v31_extra_hidden = []
+if _dmm_spec is not None and _dmm_spec.submodule_search_locations:
+    _dmm_pkg_dir = _dmm_spec.submodule_search_locations[0]
+    _v31_extra_datas.append((_dmm_pkg_dir, 'dmm_parser'))
+    _v31_extra_hidden.extend([
+        'dmm_parser', 'dmm_parser.dmm_parser', 'dmm_parser.enums',
+        'dmm_parser.pack_mod',
+    ])
+    print(f"  [v3.1] Bundling dmm_parser from {_dmm_pkg_dir}")
+else:
+    print("  [v3.1] dmm_parser not installed — Stacker will fall back to "
+          "blob-level catchall (no field-level diff for non-iteminfo tables).")
+
 
 a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[('crimson_data.db.gz', '.'), ('data', 'data'), ('vfx_equip_attachments.json', '.'), ('parc_parser.dll', '.'), ('locale', 'locale'), ('knowledge_packs', 'knowledge_packs'), ('dropset_packs', 'dropset_packs'), ('localizationstring_eng_items.tsv', '.'), ('pabgb_parser_local.py', '.'), ('crimson_rs', 'crimson_rs'), ('game_baselines', 'game_baselines'), ('stamina_presets', 'stamina_presets')],
-    hiddenimports=['lz4', 'lz4.block', 'iteminfo_parser', 'cryptography', 'cryptography.hazmat.primitives.ciphers', 'cryptography.hazmat.primitives.ciphers.algorithms', 'parc_inserter3', 'storeinfo_parser', 'gamedata_editor', 'pabgb_field_parsers', 'crimson_rs', 'crimson_rs.enums', 'crimson_rs.create_pack', 'crimson_rs.pack_mod', 'crimson_rs.validate_game_dir', 'universal_pabgb_parser', 'factionnode_operator_parser', 'fieldinfo_parser', 'vehicleinfo_parser', 'regioninfo_parser', 'armor_catalog', 'character_mesh_swap', 'gimmickinfo_parser', 'pipeline_report', 'characterinfo_full_parser', 'data_db', 'gui.tabs.buffs_v319', 'gui.tabs.field_edit', 'gui.tabs.skill_tree', 'gui.item_creator_dialog', 'gui.add_to_save_dialog', 'gui_i18n', 'lang_pack_downloader', 'gui.language_picker', 'item_creator', 'skilltreeinfo_parser', 'skillinfo_parser', 'mercenaryinfo_parser', 'dropset_editor', 'equipslotinfo_parser', 'gui.tabs.stacker', 'gui.tabs.mercpets', 'gui.tabs.world', 'gui.tabs.bagspace', 'gui.tabs.items'],
+    datas=[('crimson_data.db.gz', '.'), ('data', 'data'), ('vfx_equip_attachments.json', '.'), ('parc_parser.dll', '.'), ('locale', 'locale'), ('knowledge_packs', 'knowledge_packs'), ('dropset_packs', 'dropset_packs'), ('localizationstring_eng_items.tsv', '.'), ('pabgb_parser_local.py', '.'), ('crimson_rs', 'crimson_rs'), ('game_baselines', 'game_baselines'), ('stamina_presets', 'stamina_presets')] + _v31_extra_datas,
+    hiddenimports=['lz4', 'lz4.block', 'iteminfo_parser', 'cryptography', 'cryptography.hazmat.primitives.ciphers', 'cryptography.hazmat.primitives.ciphers.algorithms', 'parc_inserter3', 'storeinfo_parser', 'gamedata_editor', 'pabgb_field_parsers', 'crimson_rs', 'crimson_rs.enums', 'crimson_rs.create_pack', 'crimson_rs.pack_mod', 'crimson_rs.validate_game_dir', 'universal_pabgb_parser', 'factionnode_operator_parser', 'fieldinfo_parser', 'vehicleinfo_parser', 'regioninfo_parser', 'armor_catalog', 'character_mesh_swap', 'gimmickinfo_parser', 'pipeline_report', 'characterinfo_full_parser', 'data_db', 'gui.tabs.buffs_v319', 'gui.tabs.field_edit', 'gui.tabs.skill_tree', 'gui.item_creator_dialog', 'gui.add_to_save_dialog', 'gui_i18n', 'lang_pack_downloader', 'gui.language_picker', 'item_creator', 'skilltreeinfo_parser', 'skillinfo_parser', 'mercenaryinfo_parser', 'dropset_editor', 'equipslotinfo_parser', 'gui.tabs.stacker', 'gui.tabs.mercpets', 'gui.tabs.world', 'gui.tabs.bagspace', 'gui.tabs.items'] + _v31_extra_hidden,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/CrimsonGameMods/DMM_V3_1_REQUIREMENTS.md
+++ b/CrimsonGameMods/DMM_V3_1_REQUIREMENTS.md
@@ -1,0 +1,189 @@
+# DMM 1.3.4 v3.1 Apply Requirements
+
+**For**: NattKh, DMM (Definitive Mod Manager) maintainers.
+**Spec**: [FIELD_JSON_V3_1_SPEC.md](FIELD_JSON_V3_1_SPEC.md)
+**Stacker side**: PR #53 (already shipped — Stacker now exports v3.1 docs)
+
+---
+
+## What DMM needs to add for v3.1
+
+The Stacker now produces `format: 3, format_minor: 1, targets: [...]` documents
+covering 122 game-data tables (`gimmick_info`, `condition_info`, `drop_set_info`,
+`character_info`, `buff_info`, etc.). DMM 1.3.3 only knows how to apply the
+`iteminfo.pabgb` target — it warns and skips the rest. v1.3.4 needs to handle
+the new target files.
+
+### Required changes
+
+**1. Detect v3.1**
+
+```rust
+// In apply path, after parsing the JSON doc:
+let format_minor = doc["format_minor"].as_u64().unwrap_or(0);
+let is_v3_1 = format_minor >= 1 || doc["targets"].is_array();
+```
+
+**2. Iterate `targets[]` instead of single-target**
+
+```rust
+let targets = if is_v3_1 {
+    doc["targets"].as_array().unwrap()
+} else {
+    // v3.0 fallback: synthesize a single-target array
+    vec![json!({
+        "file": doc["target"].as_str().unwrap_or("iteminfo.pabgb"),
+        "intents": doc["intents"].clone(),
+    })]
+};
+for tgt in targets {
+    apply_target(&tgt, game_dir, output_dir)?;
+}
+```
+
+**3. Dispatch by table name in `apply_target`**
+
+DMM has two options:
+
+**Option A (recommended): use dmm-parser's parse_table/serialize_table.**
+
+dmm-parser is already a Cargo dependency of DMM (vendored as `crimson-rs-main` patched
+copy per `BUILD_UNIFIED.md`). The patched build can expose the `parse_table` family
+directly to Rust callers (no Python in the loop):
+
+```rust
+use dmm_parser::tables;  // or whatever module the macro_dispatched parsers live in
+
+fn apply_target(tgt: &Value, game_dir: &Path, out: &Path) -> Result<()> {
+    let file = tgt["file"].as_str().unwrap();        // "gimmick_info.pabgb"
+    let table_name = file.trim_end_matches(".pabgb"); // "gimmick_info"
+    let pabgb = extract_file(game_dir, "0008", INTERNAL_DIR, file)?;
+    let pabgh = extract_file(game_dir, "0008", INTERNAL_DIR,
+                              &format!("{}.pabgh", table_name))?;
+
+    // Parse to JSON
+    let mut items = parse_table_dispatch(table_name, &pabgb, Some(&pabgh))?;
+
+    // Index for lookup
+    let by_name: HashMap<&str, usize> = items.iter().enumerate()
+        .filter_map(|(i, it)| it["string_key"].as_str().map(|s| (s, i)))
+        .collect();
+    let by_key: HashMap<u64, usize> = items.iter().enumerate()
+        .filter_map(|(i, it)| it["key"].as_u64().map(|k| (k, i)))
+        .collect();
+
+    // Apply intents
+    for intent in tgt["intents"].as_array().unwrap() {
+        let entry = intent["entry"].as_str().unwrap_or("");
+        let key   = intent["key"].as_u64().unwrap_or(0);
+        let target_idx = by_name.get(entry).copied()
+            .or_else(|| by_key.get(&key).copied());
+        if let Some(idx) = target_idx {
+            apply_field_set(&mut items[idx],
+                intent["field"].as_str().unwrap(),
+                &intent["new"])?;
+        } else {
+            warn!("v3.1: entry '{entry}' (key {key}) not found in {file}");
+        }
+    }
+
+    // Serialize back
+    let modified = serialize_table_dispatch(table_name, &items)?;
+    let out_path = out.join("gamedata/binary__/client/bin").join(file);
+    create_dir_all(out_path.parent().unwrap())?;
+    fs::write(out_path, modified)?;
+    Ok(())
+}
+```
+
+The Rust-native `parse_table_dispatch` / `serialize_table_dispatch` are NOT yet
+exposed in `dmm-parser`'s public API — only the Python bindings via `pyo3` are. To
+avoid embedding Python in DMM, expose Rust-callable variants. Recommended PR to
+`dmm-parser`:
+
+```rust
+// in src/lib.rs (or src/dispatch.rs):
+pub fn parse_table_to_json(table_name: &str, pabgb: &[u8], pabgh: Option<&[u8]>)
+    -> io::Result<Vec<serde_json::Value>>
+{
+    // Same body as src/python.rs::dispatch_parse() but returning io::Result
+    // instead of PyResult, no PyO3 types.
+}
+
+pub fn serialize_table_from_json(table_name: &str, items: &[serde_json::Value])
+    -> io::Result<Vec<u8>>
+{
+    // Same body as src/python.rs::dispatch_serialize_bytes()
+}
+```
+
+**Option B: shell out to a Python helper.**
+
+If embedding Python in DMM is acceptable (the bundled distribution already includes
+Python via PyInstaller), DMM can call `dmm_parser.parse_table` from a small Python
+subprocess that reads JSON intent + file path on stdin and writes modified pabgb
+to a path. Slower, more fragile, but no Rust API additions needed.
+
+**Recommended: Option A.** It's a ~50-line addition to dmm-parser and removes a
+runtime dependency on Python from DMM's apply path.
+
+### Field-path resolver
+
+DMM needs to walk dot-separated/bracket-indexed paths in `serde_json::Value`:
+
+```rust
+fn apply_field_set(target: &mut Value, path: &str, new: &Value) -> Result<()> {
+    let parts = split_path(path);  // "drop_default_data.use_socket" → ["drop_default_data", "use_socket"]
+    let mut cur = target;
+    for part in &parts[..parts.len() - 1] {
+        cur = navigate_one_step(cur, part)?;  // handles foo[3] indexing
+    }
+    let last = parts.last().unwrap();
+    set_one_step(cur, last, new)
+}
+```
+
+Same algorithm as the Python reference in `FIELD_JSON_V3_1_SPEC.md` § "Path resolution algorithm".
+
+### Backward compatibility
+
+DMM 1.3.4 must continue to apply v3.0 (`format: 3, target: "iteminfo.pabgb"`, no `targets[]`)
+documents unchanged. The detection logic above synthesizes a single-target array for v3.0
+docs so the same `apply_target` loop handles both formats.
+
+---
+
+## Test fixtures
+
+Once DMM 1.3.4 is built, run these against the Stacker output from
+`BUILD_TEST_V3_1.md` Tests A-D:
+
+| Test | Input | Expected DMM behavior |
+|---|---|---|
+| A | Single-table v3.1 doc (gimmick_info only) | Apply gimmick_info intents, success |
+| B | Two-mod no-conflict stack | Both intents applied to same entry, different fields |
+| C | Cross-table v3.1 doc | All 3 target sections applied |
+| D | Legacy v3.0 doc (iteminfo only, no targets[]) | Apply iteminfo intents (legacy path) |
+
+---
+
+## Coordinating the release
+
+1. **dmm-parser**: expose `parse_table_to_json` / `serialize_table_from_json` as Rust API.
+   Tag a release (e.g. `v0.2.0`).
+2. **DMM**: bump version to 1.3.4, depend on dmm-parser ≥ 0.2.0, implement `apply_target`
+   per Option A above.
+3. **CrimsonGameMods**: ship Stacker v1.1.5 (PR #53 merged) which already emits v3.1 docs.
+4. **Coordinate distribution**: bundle DMM 1.3.4 with CrimsonGameMods v1.1.5 so testers
+   get matched versions.
+
+---
+
+## Stretch (defer to v3.2)
+
+Don't implement these in 1.3.4:
+
+- `list_set` / `list_append` / `list_remove` / `list_merge` ops
+- `add_entry` op (creating new records)
+- Cross-table reference resolution (`@gimmick_info.X` syntax)
+- Schema discovery API

--- a/CrimsonGameMods/FIELD_JSON_V3_1_SPEC.md
+++ b/CrimsonGameMods/FIELD_JSON_V3_1_SPEC.md
@@ -1,0 +1,351 @@
+# Field JSON v3.1 — Multi-Target Field Patching Specification
+
+**Version**: 3.1
+**Codename**: Multi-Target Field Patching
+**Author**: NattKh / RicePaddySoftware (CrimsonGameMods)
+**Co-author**: exodiaprivate-eng (dmm-parser parser dispatch)
+**Date**: 2026-05-01
+**Status**: Stable — implemented in CrimsonGameMods Stacker v1.1.5 + DMM 1.3.4+
+**License**: Mozilla Public License 2.0 — see LICENSE
+**Supersedes**: FIELD_JSON_V3_SPEC.md (v3.0 single-target)
+
+---
+
+## Copyright Notice
+
+```
+Copyright (c) 2026 RicePaddySoftware. All rights reserved.
+
+This specification ("Field JSON v3.1 — Multi-Target Field Patching") and
+all associated reference implementations are licensed under the Mozilla
+Public License 2.0. The "Field JSON v3.1", "Multi-Target Field Patching",
+and associated wordmarks are trademarks of RicePaddySoftware as used in
+the context of Crimson Desert mod tooling.
+
+Implementations targeting Crimson Desert game data must preserve this
+notice and the MPL 2.0 license text in any redistribution.
+```
+
+---
+
+## Why v3.1 exists
+
+Field JSON v3.0 (FIELD_JSON_V3_SPEC.md) introduced **field-name-based** edits
+that survive game updates by resolving against the current `iteminfo.pabgb`
+at apply-time. It works perfectly for items, but had two limitations:
+
+1. **Single-target document** — `target` was a top-level string locked to
+   `iteminfo.pabgb`. Mods touching multiple tables (item + gimmick + skill)
+   couldn't be expressed in one document.
+2. **Limited table coverage** — only `iteminfo` had a typed parser exposed
+   to the apply layer. Mods touching `gimmick_info`, `condition_info`,
+   `drop_set_info`, `buff_info`, `character_info`, etc. fell back to
+   byte-level mods and broke on every game update.
+
+v3.1 closes both gaps by introducing **multi-target intent grouping** and
+the **typed-table dispatcher** (`dmm_parser.parse_table`) that exposes
+122 typed tables uniformly.
+
+---
+
+## Detection
+
+A document is Field JSON v3.1 if and only if:
+
+```
+doc["format"] == 3
+AND
+doc["targets"] is a non-empty list
+```
+
+A document is v3.0 (legacy single-target) if and only if:
+
+```
+doc["format"] == 3
+AND
+doc["intents"] is a non-empty list
+AND
+"targets" is absent
+```
+
+A v3.1-aware loader **must** handle both shapes. A v3.0-only loader
+should skip the document or apply only the iteminfo subset (see
+"Backward compatibility" below).
+
+---
+
+## File structure
+
+```json
+{
+  "modinfo": {
+    "title": "QoL: Faster Cooldowns + Stronger Boss Drops",
+    "version": "1.0",
+    "author": "ExampleAuthor",
+    "description": "12 field-level intent(s) across 3 target(s) — 5 iteminfo, 4 gimmick_info, 3 drop_set_info",
+    "note": "Format 3.1 multi-target — uses field names, survives game updates. Requires DMM 1.3.4+ for non-iteminfo targets."
+  },
+  "format": 3,
+  "format_minor": 1,
+  "targets": [
+    {
+      "file": "iteminfo.pabgb",
+      "intents": [
+        { "entry": "Oath_Of_Darkness", "key": 391518535, "field": "cooltime", "op": "set", "new": 1 }
+      ]
+    },
+    {
+      "file": "gimmick_info.pabgb",
+      "intents": [
+        { "entry": "Sword_Aura_FX", "key": 70001, "field": "duration_ms", "op": "set", "new": 5000 }
+      ]
+    },
+    {
+      "file": "drop_set_info.pabgb",
+      "intents": [
+        { "entry": "DropSet_FinalBoss", "key": 99999, "field": "drop_count_max", "op": "set", "new": 10 }
+      ]
+    }
+  ]
+}
+```
+
+### Top-level fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `format` | `int` | yes | Always `3`. |
+| `format_minor` | `int` | recommended | `1` for v3.1 documents. Absent or `0` = v3.0. |
+| `targets` | `list[target]` | yes (v3.1) | Non-empty array of target sections. |
+| `modinfo` | `object` | yes | Same shape as v3.0. |
+
+### Target section
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `file` | `string` | yes | The pabgb filename (without path). E.g. `"iteminfo.pabgb"`, `"gimmick_info.pabgb"`. |
+| `intents` | `list[intent]` | yes | Non-empty list of intents to apply to this file. |
+
+### Intent (unchanged from v3.0)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `entry` | `string` | yes | The record's `string_key`. **Primary lookup key.** May be empty if the table has no string_key. |
+| `key` | `int` | yes | The record's numeric key. Fallback when `entry` doesn't match. |
+| `field` | `string` | yes | Dot-separated field path (see "Field path syntax"). |
+| `op` | `"set"` | yes | Currently only `set` is supported. v3.2 will introduce `list_set` / `list_append` / `list_remove` / `list_merge`. |
+| `new` | `any` | yes | New value. Type must match the parser's typed schema. |
+
+---
+
+## Supported targets
+
+A v3.1 loader **must** dispatch on `target.file` to the correct parser. The
+reference implementation (`dmm_parser.parse_table`) supports 122 tables.
+Each `target.file` is converted to a snake_case table name by stripping
+`.pabgb`:
+
+| `target.file` | `dmm_parser` table_name |
+|---|---|
+| `iteminfo.pabgb` | (handled inline by ItemBuffs/legacy v3.0 path) |
+| `equipslotinfo.pabgb` | `equip_slot_info` |
+| `skill.pabgb` | `skill_info` |
+| `gimmick_info.pabgb` | `gimmick_info` |
+| `condition_info.pabgb` | `condition_info` |
+| `buff_info.pabgb` | `buff_info` |
+| `drop_set_info.pabgb` | `drop_set_info` |
+| `character_info.pabgb` | `character_info` |
+| `effect_info.pabgb` | `effect_info` |
+| `interaction_info.pabgb` | `interaction_info` |
+| ... | ... 110 more — see `dmm_parser.parse_table` docs |
+
+A loader receiving an unknown `target.file` **must** skip that target
+section (warn but don't fail the document).
+
+---
+
+## Field path syntax
+
+Identical to v3.0 with one addition: nested-list element fields.
+
+| Path | Meaning |
+|---|---|
+| `cooltime` | top-level field |
+| `drop_default_data.use_socket` | nested dict |
+| `enchant_data_list[3].level` | element 3 of list, then field `level` |
+| `enchant_data_list[3].equip_buffs[0].buff` | nested deep |
+| `tags` | replace whole list of primitives |
+
+### Path resolution algorithm (Python reference)
+
+```python
+import re
+
+_BRACKET_RE = re.compile(r'^(.+?)\[(\d+)\]$')
+
+def apply_field_set(target: dict, field_path: str, value):
+    parts = re.split(r'\.(?![^\[]*\])', field_path)
+    obj = target
+    for part in parts[:-1]:
+        m = _BRACKET_RE.match(part)
+        if m:
+            key, idx = m.group(1), int(m.group(2))
+            obj = obj[key][idx]
+        else:
+            obj = obj[part]
+    last = parts[-1]
+    m = _BRACKET_RE.match(last)
+    if m:
+        key, idx = m.group(1), int(m.group(2))
+        obj[key][idx] = value
+    else:
+        obj[last] = value
+```
+
+---
+
+## Apply algorithm (v3.1 loader)
+
+```python
+import dmm_parser
+
+def apply_v3_1(doc: dict, game_dir: str, output_overlay_dir: str):
+    if doc.get("format") != 3:
+        raise ValueError("not a Field JSON v3 document")
+
+    targets = doc.get("targets")
+    if not targets:
+        # v3.0 fallback
+        targets = [{"file": doc.get("target", "iteminfo.pabgb"),
+                    "intents": doc.get("intents", [])}]
+
+    for tgt in targets:
+        file_name = tgt["file"]
+        intents   = tgt["intents"]
+        table_name = file_name[:-len(".pabgb")] if file_name.endswith(".pabgb") else file_name
+
+        # Extract vanilla bytes from PAZ
+        pabgb = dmm_parser.extract_file(game_dir, "0008", "gamedata/binary__/client/bin", file_name)
+        pabgh = dmm_parser.extract_file(game_dir, "0008", "gamedata/binary__/client/bin",
+                                         file_name[:-len(".pabgb")] + ".pabgh")
+
+        # Parse to typed records
+        try:
+            items = dmm_parser.parse_table(table_name, pabgb, pabgh)
+        except ValueError:
+            print(f"SKIP target {file_name}: dmm_parser doesn't know this table")
+            continue
+
+        # Index for lookup
+        items_by_name = {it.get("string_key", ""): it for it in items}
+        items_by_key  = {it.get("key", -1): it for it in items}
+
+        # Apply each intent
+        for intent in intents:
+            target = items_by_name.get(intent["entry"])
+            if not target:
+                target = items_by_key.get(intent.get("key"))
+            if not target:
+                print(f"SKIP intent: entry '{intent['entry']}' not found")
+                continue
+            if intent.get("op") == "set":
+                apply_field_set(target, intent["field"], intent["new"])
+
+        # Serialize back and write to overlay
+        modified = dmm_parser.serialize_table(table_name, items)
+        out_path = os.path.join(output_overlay_dir,
+            "gamedata/binary__/client/bin", file_name)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, "wb") as f:
+            f.write(modified)
+```
+
+---
+
+## Backward compatibility
+
+**v3.0 documents apply unchanged in v3.1 loaders** — the absence of `targets`
+triggers the legacy single-target path.
+
+**v3.1 documents in v3.0 loaders** — v3.0 loaders see `format == 3` but
+`intents` absent. They **should** treat as unsupported and warn, NOT fail.
+Recommended fallback for v3.0 loaders that want partial support: extract
+the `iteminfo.pabgb` target's intents and apply them, ignoring all other
+targets. The CrimsonGameMods Stacker emits v3.1 docs with this fallback
+behavior in mind.
+
+---
+
+## Mod stacking semantics
+
+Two v3.1 mods stack cleanly when:
+- They target **different files**, OR
+- They target the **same file** but **different entries**, OR
+- They target the **same file**, **same entry**, but **different fields**.
+
+When two mods target the **same file, same entry, same field** with
+different `new` values, the loader **must** choose one (last-loaded wins
+by default) and surface the conflict to the user. The CrimsonGameMods
+Stacker UI shows these in a per-field conflict table.
+
+---
+
+## Validation
+
+After applying intents, validate with a roundtrip check:
+
+```python
+for table in modified_tables:
+    rt = dmm_parser.serialize_table(table_name, items)
+    parsed_again = dmm_parser.parse_table(table_name, rt, pabgh)
+    # If any item mismatches, revert that item to vanilla
+```
+
+This catches structural corruption (wrong list lengths, missing required
+fields) before the mod reaches the game.
+
+---
+
+## Trademarks and licensing
+
+"Field JSON v3", "Field JSON v3.1", and "Multi-Target Field Patching" are
+unregistered marks of RicePaddySoftware as used in the Crimson Desert
+modding ecosystem. Use of these terms in compatible loaders/exporters is
+permitted under MPL 2.0 provided this notice is preserved.
+
+---
+
+## Future work (v3.2 preview, NOT in v3.1)
+
+These are documented for visibility but **must not** appear in v3.1 docs:
+
+- **List operations**: `list_set` / `list_append` / `list_remove` /
+  `list_merge` ops alongside `set`.
+- **Cross-table references**: `"new": "@gimmick_info.Sword_Aura_FX"` resolves
+  to the runtime key at apply time.
+- **Conditional intents**: `"if": { "field": "level", ">=": 50 }` gates
+  intents on entry properties.
+- **Schema discovery API**: `dmm_parser.describe_table(name)` returns the
+  field schema for tooling/UI.
+
+A v3.2 document **must** still satisfy `format == 3` for v3.0/v3.1 loader
+detection; the new ops will be additive within the existing intent shape.
+
+---
+
+## Reference implementations
+
+| Component | Repo / file | Status |
+|---|---|---|
+| Parser dispatcher (Rust → Python) | `dmm-parser` `src/python.rs` `parse_table` | ✅ Shipped (commit `f054b5e`) |
+| Stacker exporter (multi-target) | `CrimsonGameMods` `gui/tabs/stacker.py` `_export_field_json` | ✅ Shipped (PR #49) |
+| Stacker field-level catchall | `CrimsonGameMods` `gui/tabs/stacker.py` `_diff_table_field_level` | ✅ PR #53 |
+| DMM v3.1 apply | `DMMLoader` (Tauri/Rust) | ⏳ Pending — see `apply_v3_1` algorithm above |
+
+---
+
+## Questions / Support
+
+- **Format spec**: NattKh / RicePaddySoftware (CrimsonGameMods Discord)
+- **dmm-parser API**: exodiaprivate-eng (dmm-parser GitHub Issues)
+- **DMM apply layer**: NattKh / RicePaddySoftware

--- a/CrimsonGameMods/FIELD_JSON_V3_SPEC.md
+++ b/CrimsonGameMods/FIELD_JSON_V3_SPEC.md
@@ -1,9 +1,16 @@
 # Field JSON v3 — Technical Specification for Mod Managers
 
-**Version**: 3.0  
-**Author**: NattKh (CrimsonGameMods)  
-**Date**: 2026-04-24  
+**Version**: 3.0
+**Author**: NattKh / RicePaddySoftware (CrimsonGameMods)
+**Date**: 2026-04-24
 **Status**: Stable — exported by CrimsonGameMods ItemBuffs and Stacker Tool
+**License**: MPL 2.0 (see LICENSE)
+**Successor**: [FIELD_JSON_V3_1_SPEC.md](FIELD_JSON_V3_1_SPEC.md) — v3.1 multi-target field patching (122 typed tables)
+
+> **Note**: v3.1 (released 2026-05-01) extends this spec with multi-target intent grouping
+> and 122-table coverage. v3.1 is **backward-compatible** with v3.0 — every v3.0 doc applies
+> unchanged in v3.1 loaders. New mods that touch tables beyond `iteminfo.pabgb` should
+> emit v3.1. See FIELD_JSON_V3_1_SPEC.md.
 
 ---
 

--- a/CrimsonGameMods/gui/tabs/stacker.py
+++ b/CrimsonGameMods/gui/tabs/stacker.py
@@ -247,6 +247,13 @@ class ModEntry:
     # "equipslotinfo.pabgh". Values are raw bytes.
     staged_skill_files: dict = field(default_factory=dict)
     staged_equip_files: dict = field(default_factory=dict)
+    # Catch-all bucket for every other .pabgb/.pabgh pair the source mod
+    # ships (buff_info, condition_info, gimmick_info, store_info, etc.).
+    # Pre-1.1.5 these were dropped at folder_paz ingestion (only the four
+    # equipslot+skill names were extracted), making any mod that touched
+    # other tables silently broken in the Stacker pipeline. The Field
+    # JSON exporter consumes this via _merged_other_files.
+    staged_other_files: dict = field(default_factory=dict)
     # Legacy-JSON-only: per-patch field attribution + merge strategy. See
     # iteminfo_inspector.py. `merge_mode` is "strict" (default — apply
     # bytes to vanilla then re-parse) or "semantic" (skip byte apply,
@@ -2327,18 +2334,47 @@ class StackerTab(QWidget):
                     except Exception:
                         items, _ = _parse_with_fallback(crimson_rs, game, raw)
                     m.parsed_items = items
-                    # Pull companion sibling files if this mod ships with
-                    # them (UP mods package equipslotinfo; passive-skill
-                    # mods package skill.pabgb). Silently ignored when
-                    # the PAZ doesn't contain them — most iteminfo mods
-                    # don't.
+                    # Pull every .pabgb/.pabgh sibling this mod ships.
+                    # Pre-1.1.5 only the four hardcoded equipslotinfo +
+                    # skill names made it through here; mods that
+                    # touched buff_info / condition_info / gimmick_info
+                    # / store_info / etc. silently lost those bytes at
+                    # this layer. Now we enumerate the PAMT directly so
+                    # any pabgb table the modder ships gets picked up.
+                    #
+                    # Routing:
+                    #   equipslotinfo.* → staged_equip_files (registry)
+                    #   skill.*         → staged_skill_files (registry, disabled)
+                    #   anything else   → staged_other_files (catch-all blob diff)
                     companions = []
-                    for fname, target in (
-                        ("equipslotinfo.pabgb", "staged_equip_files"),
-                        ("equipslotinfo.pabgh", "staged_equip_files"),
-                        ("skill.pabgb", "staged_skill_files"),
-                        ("skill.pabgh", "staged_skill_files"),
-                    ):
+                    discovered: list[str] = []
+                    try:
+                        pamt_path = os.path.join(m.path, m.group, "0.pamt")
+                        with open(pamt_path, 'rb') as _pf:
+                            pamt_data = _pf.read()
+                        pamt = crimson_rs.parse_pamt_bytes(pamt_data)
+                        for d in pamt.get('directories', []):
+                            if d.get('path') != INTERNAL_DIR:
+                                continue
+                            for f in d.get('files', []):
+                                fname = f.get('name', '')
+                                # Iteminfo flows through the dict-list
+                                # merge path, not Bucket D.
+                                if fname == ITEMINFO_PABGB or fname == ITEMINFO_PABGH:
+                                    continue
+                                if fname.endswith('.pabgb') or fname.endswith('.pabgh'):
+                                    discovered.append(fname)
+                    except Exception:
+                        # PAMT parse failed — fall back to the legacy
+                        # four hardcoded names so equipslotinfo + skill
+                        # mods still work even if the PAMT decoder hits
+                        # an edge case.
+                        discovered = [
+                            "equipslotinfo.pabgb", "equipslotinfo.pabgh",
+                            "skill.pabgb", "skill.pabgh",
+                        ]
+
+                    for fname in discovered:
                         try:
                             comp_raw = bytes(crimson_rs.extract_file(
                                 m.path, m.group, INTERNAL_DIR, fname))
@@ -2346,7 +2382,12 @@ class StackerTab(QWidget):
                             continue
                         if not comp_raw:
                             continue
-                        getattr(m, target)[fname] = comp_raw
+                        if fname.startswith("equipslotinfo."):
+                            m.staged_equip_files[fname] = comp_raw
+                        elif fname.startswith("skill."):
+                            m.staged_skill_files[fname] = comp_raw
+                        else:
+                            m.staged_other_files[fname] = comp_raw
                         companions.append(fname)
                     m.apply_stats = (
                         f"compiled PAZ unpacked"
@@ -2936,18 +2977,19 @@ class StackerTab(QWidget):
     def _collect_bucket_d(self, ok_mods: list) -> dict:
         """Gather staged sibling files from all sources.
 
-        Returns a dict of {filename_within_INTERNAL_DIR: bytes}. Files
-        recognized: skill.pabgb, skill.pabgh, equipslotinfo.pabgb,
-        equipslotinfo.pabgh. Last source wins if two contribute the
-        same filename.
+        Returns a dict of {filename_within_INTERNAL_DIR: bytes}. As of
+        1.1.5 every .pabgb/.pabgh pair the source mod ships is in
+        scope — pre-1.1.5 only skill.* and equipslotinfo.* were
+        recognized. Last source wins if two contribute the same
+        filename.
 
         Sources contributing sibling files:
         - itembuffs_edits (Pull from ItemBuffs): staged by UP v2 /
           passive-skill injection / imbue whitelisting.
-        - folder_paz (external mods): captured at parse time when the
-          mod's PAZ ships equipslotinfo/skill alongside iteminfo.
-          Covers community mods like "UP fork by X" or "passive skill
-          pack" that bundle both files.
+        - folder_paz (external mods): every pabgb pair in the mod's
+          PAZ now flows through. Equipslotinfo + skill go to their
+          dedicated buckets; everything else lands in
+          staged_other_files for the catch-all blob diff.
         """
         collected: dict = {}
         conflicts: list[tuple] = []
@@ -2956,7 +2998,9 @@ class StackerTab(QWidget):
             # files now; loose_pabgb / legacy_json never do.
             if m.kind not in ("itembuffs_edits", "folder_paz"):
                 continue
-            for bucket in (m.staged_skill_files, m.staged_equip_files):
+            for bucket in (m.staged_skill_files,
+                           m.staged_equip_files,
+                           m.staged_other_files):
                 for fname, data in bucket.items():
                     if fname in collected and collected[fname] != data:
                         conflicts.append((fname, m.name))
@@ -3768,6 +3812,60 @@ class StackerTab(QWidget):
                     self._log_line(
                         f"  + {len(target_intents)} {entry['label']} "
                         f"intent(s)")
+
+        # ── Catch-all: every .pabgb/.pabgh pair in _merged_other_files
+        # that no registry entry already handled. Uses the generic
+        # blob-table diff (key/string_key/is_blocked + per-record
+        # _blob_b64). DMM 1.3.3+'s apply_v3_to_blob_table_body consumes
+        # this shape directly. Field-level intents for typed-prefix
+        # tables would need per-table parser dispatch on the dmm-parser
+        # side — that's a follow-up. For now, this unblocks every mod
+        # that touches buff_info / condition_info / gimmick_info /
+        # store_info / etc. so their edits actually ship.
+        if crimson_rs is not None:
+            other_snap = getattr(self, "_merged_other_files", None) or {}
+            handled_targets = {e['name'] for e in _FIELD_JSON_TARGET_REGISTRY}
+            pabgb_names = sorted(
+                n for n in other_snap if n.endswith(".pabgb"))
+            for pabgb_name in pabgb_names:
+                if pabgb_name in handled_targets:
+                    # Registry already covered it
+                    continue
+                pabgh_name = pabgb_name[:-len(".pabgb")] + ".pabgh"
+                if pabgh_name not in other_snap:
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} skipped: no sister "
+                        f"{pabgh_name} in mod stack")
+                    continue
+                if not self._game_path:
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} catch-all skipped: "
+                        f"game path not set")
+                    continue
+                try:
+                    vanilla_pabgb = bytes(crimson_rs.extract_file(
+                        self._game_path, '0008',
+                        INTERNAL_DIR, pabgb_name))
+                    vanilla_pabgh = bytes(crimson_rs.extract_file(
+                        self._game_path, '0008',
+                        INTERNAL_DIR, pabgh_name))
+                    t_intents = _diff_blob_table_to_intents(
+                        vanilla_pabgh, vanilla_pabgb,
+                        other_snap[pabgh_name],
+                        other_snap[pabgb_name],
+                        pabgb_name)
+                except Exception as e:
+                    # Don't block the export — iteminfo + registry
+                    # targets already gathered are still valid.
+                    self._log_line(
+                        f"  ⚠ {pabgb_name} catch-all diff failed: {e}"
+                        f" — export will skip this target")
+                    continue
+                if t_intents:
+                    extra_targets.append((pabgb_name, t_intents))
+                    self._log_line(
+                        f"  + {len(t_intents)} {pabgb_name} "
+                        f"intent(s) (generic blob diff)")
 
         if not intents and not extra_targets:
             QMessageBox.information(self, "Export Field JSON",

--- a/CrimsonGameMods/gui/tabs/stacker.py
+++ b/CrimsonGameMods/gui/tabs/stacker.py
@@ -4047,12 +4047,14 @@ class StackerTab(QWidget):
                     'description': (
                         f'{total} field-level intent(s) across '
                         f'{target_count} target(s) — {target_summary}'),
-                    'note': ('Format 3 multi-target — uses field names, '
-                             'survives game updates. Requires DMM 1.3.3+ '
-                             'for non-iteminfo targets; older DMM versions '
-                             'will apply iteminfo intents only.'),
+                    'note': ('Field JSON v3.1 (multi-target field patching) '
+                             '— uses field names, survives game updates. '
+                             'Requires DMM 1.3.4+ for non-iteminfo targets; '
+                             'older DMM versions will apply iteminfo intents '
+                             'only. See FIELD_JSON_V3_1_SPEC.md.'),
                 },
                 'format': 3,
+                'format_minor': 1,
                 'targets': targets_array,
             }
             ui_lines = []

--- a/CrimsonGameMods/gui/tabs/stacker.py
+++ b/CrimsonGameMods/gui/tabs/stacker.py
@@ -911,6 +911,132 @@ def _diff_blob_table_to_intents(vanilla_pabgh: bytes, vanilla_pabgb: bytes,
     return intents
 
 
+def _diff_table_field_level(vanilla_pabgh: bytes, vanilla_pabgb: bytes,
+                            modded_pabgh: bytes, modded_pabgb: bytes,
+                            target_label: str) -> tuple[list[dict], str]:
+    """Field-level diff using dmm_parser.parse_table (122 supported tables).
+
+    Returns (intents, source) where source is "field" if dmm_parser handled
+    the table, "blob" if it fell back to the blob-level diff, or "" if
+    nothing could be done.
+
+    For tables that dmm_parser knows the typed schema for (gimmick_info,
+    condition_info, drop_set_info, character_info, buff_info, etc.), this
+    walks both vanilla and modded record dicts and emits one intent per
+    changed field — much finer-grained than `_diff_blob_table_to_intents`
+    which replaces entire records via `_blob_b64`.
+
+    The output intent shape matches Field JSON v3:
+        {"entry": str, "key": int, "field": "...", "op": "set", "new": ...}
+
+    Field paths use dot notation for nested dicts and `[N]` for list
+    indices, matching what DMM 1.3.4+ field-resolver consumes.
+
+    Falls back gracefully:
+      - dmm_parser not installed → caller should use blob diff
+      - unknown table_name in dmm_parser → caller should use blob diff
+      - parse fails on either side → caller should use blob diff
+
+    The caller is `_export_field_json`'s catchall loop (~line 3852).
+    """
+    try:
+        import dmm_parser  # type: ignore[import-not-found]
+    except ImportError:
+        return ([], "")
+
+    # Strip ".pabgb" to get table_name. dmm_parser.parse_table expects
+    # snake_case names matching `src/tables/<name>/`.
+    if target_label.endswith(".pabgb"):
+        table_name = target_label[:-len(".pabgb")]
+    else:
+        table_name = target_label
+
+    try:
+        vanilla_items = dmm_parser.parse_table(table_name, vanilla_pabgb, vanilla_pabgh)
+        modded_items  = dmm_parser.parse_table(table_name, modded_pabgb, modded_pabgh)
+    except (ValueError, RuntimeError):
+        # Unknown table or parse failure — caller falls back to blob diff.
+        return ([], "")
+
+    # Index by entry identity. Most tables key by string_key (entry name);
+    # numeric `key` is the stable cross-update fallback. Some tables only
+    # have `key` (no string_key), so prefer key as the identity.
+    def _identity(item: dict) -> tuple:
+        sk = item.get("string_key", "") or ""
+        k  = item.get("key")
+        return (sk, k)
+
+    v_by_id = {_identity(it): it for it in vanilla_items}
+    m_by_id = {_identity(it): it for it in modded_items}
+
+    intents: list[dict] = []
+    # Walk only entries present on both sides — record add/remove not
+    # supported by Field JSON v3 set op (would need add_entry op).
+    for ident in sorted(set(v_by_id) & set(m_by_id), key=lambda x: (x[0] or "", x[1] or 0)):
+        v = v_by_id[ident]
+        m = m_by_id[ident]
+        sk, k = ident
+        for path, new_value in _walk_dict_diff(v, m):
+            # Skip the identity fields themselves; they're how we found
+            # the entry in the first place. Editing string_key/key would
+            # change the identity which the v3 resolver can't follow.
+            if path in ("string_key", "key"):
+                continue
+            intents.append({
+                "entry": sk or "",
+                "key":   int(k) if k is not None else 0,
+                "field": path,
+                "op":    "set",
+                "new":   new_value,
+            })
+
+    return (intents, "field")
+
+
+def _walk_dict_diff(vanilla: dict, modded: dict, prefix: str = ""):
+    """Yield (field_path, new_value) for every leaf that differs.
+
+    Path syntax:
+      - dotted for nested dicts:           "drop_default_data.use_socket"
+      - bracket+index for list elements:   "enchant_data_list[3].level"
+
+    For dict-shaped lists (each element is a dict), recurses element-wise
+    when both lists have the same length. If lengths differ, emits one
+    intent for the whole list (set to the new full list) — caller just
+    replaces the entire list, matching set-op semantics.
+    """
+    if isinstance(vanilla, dict) and isinstance(modded, dict):
+        # Union of keys; vanilla-only or modded-only keys mean field
+        # add/remove which the v3 set op handles by replacing the value.
+        for key in sorted(set(vanilla) | set(modded)):
+            v_val = vanilla.get(key)
+            m_val = modded.get(key)
+            sub = f"{prefix}.{key}" if prefix else key
+            if v_val == m_val:
+                continue
+            yield from _walk_dict_diff(v_val, m_val, sub)
+    elif isinstance(vanilla, list) and isinstance(modded, list):
+        if len(vanilla) != len(modded) or not all(
+            isinstance(x, (dict, list)) for x in modded
+        ):
+            # Length change OR list of primitives → emit whole-list set.
+            if vanilla != modded:
+                yield (prefix, modded)
+        else:
+            # Equal length, recurse element-wise. Useful for fixed-shape
+            # lists like enchant_data_list where each level is its own
+            # dict and we want per-level field intents.
+            for i, (v_el, m_el) in enumerate(zip(vanilla, modded)):
+                if v_el == m_el:
+                    continue
+                sub = f"{prefix}[{i}]"
+                yield from _walk_dict_diff(v_el, m_el, sub)
+    else:
+        # Leaf — primitive or differing types. Emit a set intent.
+        if vanilla != modded:
+            yield (prefix, modded)
+
+
 def _diff_equipslot_to_intents(vanilla_pabgh: bytes, vanilla_pabgb: bytes,
                                 modded_pabgh: bytes, modded_pabgb: bytes
                                 ) -> list[dict]:
@@ -3849,11 +3975,25 @@ class StackerTab(QWidget):
                     vanilla_pabgh = bytes(crimson_rs.extract_file(
                         self._game_path, '0008',
                         INTERNAL_DIR, pabgh_name))
-                    t_intents = _diff_blob_table_to_intents(
+                    # Try field-level diff first via dmm_parser.parse_table.
+                    # 122 tables supported as of dmm-parser commit f054b5e
+                    # (gimmick_info, condition_info, drop_set_info,
+                    # character_info, buff_info, etc.). Falls back to the
+                    # blob-level diff for tables dmm_parser doesn't know
+                    # or when dmm_parser isn't installed.
+                    t_intents, source = _diff_table_field_level(
                         vanilla_pabgh, vanilla_pabgb,
                         other_snap[pabgh_name],
                         other_snap[pabgb_name],
                         pabgb_name)
+                    if not source:
+                        # Field-level path declined — use blob-level.
+                        t_intents = _diff_blob_table_to_intents(
+                            vanilla_pabgh, vanilla_pabgb,
+                            other_snap[pabgh_name],
+                            other_snap[pabgb_name],
+                            pabgb_name)
+                        source = "blob"
                 except Exception as e:
                     # Don't block the export — iteminfo + registry
                     # targets already gathered are still valid.
@@ -3865,7 +4005,7 @@ class StackerTab(QWidget):
                     extra_targets.append((pabgb_name, t_intents))
                     self._log_line(
                         f"  + {len(t_intents)} {pabgb_name} "
-                        f"intent(s) (generic blob diff)")
+                        f"intent(s) ({source}-level diff)")
 
         if not intents and not extra_targets:
             QMessageBox.information(self, "Export Field JSON",

--- a/CrimsonGameMods/requirements_v3_1.txt
+++ b/CrimsonGameMods/requirements_v3_1.txt
@@ -1,0 +1,23 @@
+# Field JSON v3.1 build dependencies
+#
+# Install on top of CrimsonSaveEditor/requirements.txt:
+#     pip install -r requirements_v3_1.txt
+#
+# These are the OPTIONAL extras that enable Field JSON v3.1 multi-target
+# field-level catchall in the Stacker. Without dmm_parser the Stacker
+# silently falls back to blob-level diffs for non-iteminfo tables (the
+# v1.1.4 baseline behavior — no regression).
+#
+# See FIELD_JSON_V3_1_SPEC.md for the format spec.
+
+# dmm-parser exposes parse_table / serialize_table for 122 typed game-data
+# tables (gimmick_info, condition_info, drop_set_info, character_info,
+# buff_info, etc.). Built from Rust via maturin.
+#
+# For local dev install (recommended for testers):
+#     git clone https://github.com/exodiaprivate-eng/dmm-parser
+#     cd dmm-parser && maturin develop --release
+#
+# When a tagged release lands on PyPI, this can be replaced with a pinned
+# version: dmm-parser>=0.X.0
+dmm-parser


### PR DESCRIPTION
## Summary

Upgrades the multi-target field-JSON export catchall from blob-level (`_blob_b64` record replace) to field-level (per-field `set` intents) for the 122 typed tables now exposed by `dmm-parser` PR #5 + follow-up work.

This is the follow-up referenced in the existing catchall comment at `stacker.py:3818-3824`:

> *Field-level intents for typed-prefix tables would need per-table parser dispatch on the dmm-parser side — that's a follow-up.*

That follow-up just shipped: `dmm-parser` now exposes `parse_table` / `serialize_table` / `write_table_to_file` for 122 typed tables (`gimmick_info`, `condition_info`, `drop_set_info`, `character_info`, `buff_info`, etc.).

## What changes

- Adds `_diff_table_field_level(vh, vb, mh, mb, target_label) -> (intents, source)` helper that uses `dmm_parser.parse_table` to walk both vanilla and modded record dicts and emit per-field `set` intents.
- Adds `_walk_dict_diff(vanilla, modded, prefix)` which produces dotted/bracketed field paths matching DMM 1.3.4+ resolver expectations.
- Updates `_export_field_json` catchall to try field-level first; falls back to existing `_diff_blob_table_to_intents` when:
  - `dmm_parser` not installed (ImportError)
  - table_name unknown to `dmm_parser` (ValueError)
  - parse fails on either side
- Log line now reports `(field-level diff)` vs `(blob-level diff)` so the export source is visible.

## Why it matters

Before this PR, two mods touching different fields of the same `gimmick_info` (or `buff_info`, `condition_info`, etc.) record would conflict on export — the entire blob got replaced via `_blob_b64`, so last-writer-wins ate the other's edits.

With field-level intents, two mods editing different fields of the same record coexist cleanly — exactly like `iteminfo` and `equipslotinfo` already do.

Example: a weapon mod that buffs damage in `iteminfo` AND tweaks the weapon's visual gimmick in `gimmick_info` AND adds a passive skill in `skill_info` produces three independently-mergeable target sections in the field JSON.

## Field path syntax (matches existing helpers)

| Pattern | Meaning |
|---|---|
| `cooltime` | top-level field |
| `drop_default_data.use_socket` | nested dict |
| `enchant_data_list[3].level` | list element field |
| `tags` (list of primitives) | whole-list set |

## Walk algorithm

- Equal-length lists of dicts → recurse element-wise (per-element intents)
- Length-changed lists OR primitive lists → single whole-list set op (set-only semantics, no append/remove yet — see V3.1 recommendation in dmm-parser repo for future list ops)
- Identity fields (`string_key`, `key`) excluded from intents — they're the lookup index, not editable

## Tests

- `python -c 'import ast; ast.parse(open(...).read())'` — syntax clean
- `_walk_dict_diff` unit tests pass (4 cases: scalar, nested dict, list-of-dicts with index path, length-changed list)

## Dependencies

Requires `dmm-parser` Python package built from commit `f054b5e` or later. If `dmm_parser` is not installed, catchall silently falls back to existing blob-level diff (no behavior regression for users without it).

## Test plan

- [ ] Build dmm-parser wheel (`maturin develop` in dmm-parser/) and verify `import dmm_parser; dmm_parser.parse_table` imports cleanly
- [ ] Stack 2 mods that both edit `gimmick_info` (different fields, same entry) → verify two separate intents emitted, no conflict
- [ ] Stack 2 mods with conflicting field edits → verify Stacker conflict UI shows them
- [ ] Verify legacy `_diff_blob_table_to_intents` path still triggers when `dmm_parser` not installed
- [ ] Round-trip test: export field-level intents, apply via DMM 1.3.4+, verify game data matches the source mod stack