### PR TITLE
fix(v3 export): canonical intent shape in reserveslot + Stacker Inspector exports

### DIFF
--- a/CrimsonGameMods/gui/tabs/mod_loader.py
+++ b/CrimsonGameMods/gui/tabs/mod_loader.py
@@ -793,7 +793,32 @@ class ModLoaderTab(QWidget):
             )
 
     def _export_format3(self) -> None:
-        """Export successfully analyzed mods as Format 3 semantic JSON."""
+        """Export successfully analyzed mods as Format 3 semantic JSON.
+
+        Pre-fix the emitted intents had a broken shape:
+          * ``value`` instead of ``new`` (DMM's ``op:set`` requires
+            ``new``; ``value`` is reserved for ``array_append``)
+          * missing ``key`` (DMM falls back to ``entry`` lookup but
+            misses every record where the entry's string_key changed
+            across game versions)
+          * extra ``type`` field (harmless — DMM ignores)
+          * extra ``op`` field omitted entirely (defaulted to "set" via
+            DMM's missing-field default — works but explicit is clearer)
+          * doc envelope had no ``target`` or ``targets[]`` so DMM
+            defaulted to ``iteminfo.pabgb`` regardless of which table
+            the converted mod actually targeted
+
+        Net effect: every exported intent failed in DMM with "missing
+        new value" because of the ``value``/``new`` mismatch, AND when
+        the underlying mod targeted anything other than iteminfo the
+        intents got dispatched to the wrong table.
+
+        Post-fix uses the canonical v3 ``{entry, key, field, op:"set",
+        new}`` shape, includes the numeric ``key`` when the inspection
+        resolved one, and emits a multi-target ``targets[]`` envelope
+        keyed by each inspection's pabgb filename so downstream loaders
+        dispatch correctly.
+        """
         if not self._last_convert_results:
             return
 
@@ -807,36 +832,78 @@ class ModLoaderTab(QWidget):
             if r["status"] != "ok" or r["resolved"] == 0:
                 continue
             inspections = r["inspections"]
-            intents = []
+
+            # Bucket intents by target pabgb filename. Inspections may
+            # carry the target via .target_file / .game_file / similar;
+            # fall back to iteminfo.pabgb only when no per-inspection
+            # target is exposed (matches the legacy default behavior so
+            # this fix doesn't silently re-route iteminfo-targeted
+            # inspections).
+            buckets: dict[str, list[dict]] = {}
             for insp in inspections:
                 if insp.field_path is None or insp.new_value is None:
                     continue
-                intents.append({
-                    "entry": insp.entry,
+                target = (
+                    getattr(insp, "target_file", None)
+                    or getattr(insp, "game_file", None)
+                    or getattr(insp, "pabgb", None)
+                    or "iteminfo.pabgb"
+                )
+                # Strip leading "gamedata/" so the target is a bare
+                # filename (DMM's normalize layer accepts both, but
+                # bare is the canonical form per FIELD_JSON_V3_SPEC).
+                if isinstance(target, str) and target.startswith("gamedata/"):
+                    target = target[len("gamedata/"):]
+                intent: dict = {
+                    "entry": insp.entry or "",
                     "field": insp.field_path,
-                    "value": insp.new_value,
-                    "type": insp.field_ty or "unknown",
-                })
-            if not intents:
+                    "op": "set",
+                    "new": insp.new_value,
+                }
+                # Numeric key when the inspection found one — gives DMM
+                # a stable index for records whose string_key may have
+                # been renamed across game versions.
+                key = getattr(insp, "key", None)
+                if key is not None:
+                    intent["key"] = int(key)
+                buckets.setdefault(target, []).append(intent)
+            if not buckets:
                 continue
 
             doc = r.get("doc", {})
             info = doc.get("modinfo") or doc
-            out = {
-                "format": 3,
-                "modinfo": {
-                    "title": info.get("title") or info.get("name") or r["file"],
-                    "author": info.get("author", ""),
-                    "version": info.get("version", ""),
-                    "description": (
-                        f"Semantic conversion of {r['file']}. "
-                        f"{len(intents)} field edits from {r['total']} byte patches."
-                    ),
-                    "converted_from": r["file"],
-                    "conversion_tool": "CrimsonGameMods Stacker Inspector",
-                },
-                "intents": intents,
+            total_intents = sum(len(v) for v in buckets.values())
+            modinfo = {
+                "title": info.get("title") or info.get("name") or r["file"],
+                "author": info.get("author", ""),
+                "version": info.get("version", ""),
+                "description": (
+                    f"Semantic conversion of {r['file']}. "
+                    f"{total_intents} field edits from {r['total']} byte patches."
+                ),
+                "converted_from": r["file"],
+                "conversion_tool": "CrimsonGameMods Stacker Inspector",
             }
+            # Multi-target shape when more than one pabgb is touched —
+            # legacy single-target shape otherwise so older loaders that
+            # haven't adopted targets[] still consume the file.
+            if len(buckets) == 1:
+                only_target, only_intents = next(iter(buckets.items()))
+                out = {
+                    "format": 3,
+                    "modinfo": modinfo,
+                    "target": only_target,
+                    "intents": only_intents,
+                }
+            else:
+                out = {
+                    "format": 3,
+                    "modinfo": modinfo,
+                    "targets": [
+                        {"file": target, "intents": ints}
+                        for target, ints in buckets.items()
+                    ],
+                }
             base = Path(r["file"]).stem
             out_path = os.path.join(export_dir, f"{base}_semantic.json")
             with open(out_path, "w", encoding="utf-8") as f:

--- a/CrimsonGameMods/gui/tabs/reserveslot.py
+++ b/CrimsonGameMods/gui/tabs/reserveslot.py
@@ -356,6 +356,30 @@ class ReserveSlotTab(QWidget):
             QMessageBox.critical(self, "Apply", f"Failed:\n{e}")
 
     def _export_field_json(self) -> None:
+        """Export reserveslot edits as Format 3 field-level JSON.
+
+        Pre-fix the intent shape was bespoke and v3-loader-incompatible:
+        ``{key, name, field: "_enableVehicleList", value, vanilla}`` with
+        the doc envelope using ``table: "reserveslot"`` and no
+        ``modinfo`` block. DMM (and any spec-compliant v3 loader) rejects
+        every intent because:
+          * ``value`` is not the ``op:set`` payload field — that's ``new``
+          * ``name`` is not a recognized lookup key — that's ``entry``
+          * ``op`` defaulted to "set" via missing-field default but the
+            intent had no usable ``new`` so apply still skipped with
+            "missing new value"
+          * the doc had no ``target`` / ``targets[]`` so the loader
+            defaulted to iteminfo and tried to apply reserveslot intents
+            against the wrong table
+          * the field name used the Korean-prefixed C++ name
+            (``_enableVehicleList``) instead of the snake_case dispatch
+            name (``enable_vehicle_list``) — mismatch even after the
+            other shape issues are fixed
+
+        Post-fix uses the canonical v3 shape, snake_case field names,
+        and the standard ``target: "reserveslotinfo.pabgb"`` envelope so
+        DMM's typed apply path resolves it cleanly.
+        """
         if not self._entries or not self._vanilla_pabgh:
             QMessageBox.warning(self, "Export", "Load reserveslot first.")
             return
@@ -373,11 +397,11 @@ class ReserveSlotTab(QWidget):
                 continue
             if entry.enable_vehicle_list != van.enable_vehicle_list:
                 intents.append({
+                    "entry": entry.name or "",
                     "key": entry.key,
-                    "name": entry.name,
-                    "field": "_enableVehicleList",
-                    "value": entry.enable_vehicle_list,
-                    "vanilla": van.enable_vehicle_list,
+                    "field": "enable_vehicle_list",
+                    "op": "set",
+                    "new": list(entry.enable_vehicle_list),
                 })
 
         if not intents:
@@ -386,15 +410,21 @@ class ReserveSlotTab(QWidget):
 
         from PySide6.QtWidgets import QFileDialog
         path, _ = QFileDialog.getSaveFileName(
-            self, "Export Field JSON", "reserveslot_mod.json",
-            "JSON Files (*.json)")
+            self, "Export Field JSON", "reserveslot_mod.field.json",
+            "Field JSON (*.field.json *.json);;All Files (*)")
         if not path:
             return
 
         doc = {
+            "modinfo": {
+                "title": "ReserveSlot Mod",
+                "version": "1.0",
+                "author": "CrimsonGameMods ReserveSlot Editor",
+                "description": f"{len(intents)} field-level intent(s)",
+                "note": "Format 3 — uses field names, survives game updates",
+            },
             "format": 3,
-            "table": "reserveslot",
-            "tool": "CrimsonGameMods ReserveSlot Editor",
+            "target": "reserveslotinfo.pabgb",
             "intents": intents,
         }
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Two more v3 exporters in this repo emit `.field.json` files that no spec-compliant loader (DMM, Stacker, etc.) can apply. Both produce silently-broken output — mods deploy without errors, mount logs report "0 of N intents applied," and users see no in-game effect.

Found while auditing the codebase after #62 (Universal Proficiency / buffs_v319 fix). Same general failure mode: bespoke intent dict keys that diverge from the v3 spec's canonical `{entry, key, field, op, new}` shape, or doc envelopes missing the target table identifier.

## Bug 1 — `gui/tabs/reserveslot.py::_export_field_json`

Pre-fix:

```python
intents.append({
    "key": entry.key,
    "name": entry.name,                       # ← should be "entry"
    "field": "_enableVehicleList",            # ← Korean-prefixed C++ name
    "value": entry.enable_vehicle_list,       # ← should be "new"
    "vanilla": van.enable_vehicle_list,       # ← v3 spec has no "vanilla" field
})
# ...
doc = {
    "format": 3,
    "table": "reserveslot",                   # ← should be "target"
    "tool": "...",
    "intents": intents,
    # no modinfo
}
```

Every intent is rejected at parse time on a strict loader. On a forgiving loader (DMM via `#[serde(default)]` on the `Intent` struct), `entry` defaults to empty string and `name` is dropped → record lookup fails. Even if record lookup succeeded, `op` defaults to `"set"` but `new` is `None` because the value lives under `value`, so apply skips with "missing new value".

Post-fix uses canonical shape:

```python
intents.append({
    "entry": entry.name or "",
    "key": entry.key,
    "field": "enable_vehicle_list",          # snake_case canonical
    "op": "set",
    "new": list(entry.enable_vehicle_list),
})
doc = {
    "modinfo": { ... },
    "format": 3,
    "target": "reserveslotinfo.pabgb",
    "intents": intents,
}
```

Field name swapped from `_enableVehicleList` (the v3.1 alias) to `enable_vehicle_list` (the snake_case canonical that dmm-parser's `field_aliases_v3_1.rs` registers as the default emit name). Both are accepted on input but snake_case is what every other v3 export in this repo emits, so this brings reserveslot in line.

## Bug 2 — `gui/tabs/mod_loader.py::_export_format3` (Stacker Inspector "Format 3 export")

Pre-fix:

```python
intents.append({
    "entry": insp.entry,
    "field": insp.field_path,
    "value": insp.new_value,                  # ← should be "new"
    "type": insp.field_ty or "unknown",       # ← v3 spec has no "type" field
})
# ...
out = {
    "format": 3,
    "modinfo": { ... },
    "intents": intents,
    # no target / targets[] — defaults to iteminfo.pabgb
}
```

Same `value`/`new` mismatch. Worse: doc envelope has no target identifier, so DMM (and any loader matching the spec's "default to iteminfo when missing" behavior) routes intents to iteminfo regardless of which table the underlying mod actually patched. A characterinfo or skill-targeting Format 1/2 mod converted via Stacker Inspector would silently re-target iteminfo and apply nothing.

Post-fix uses canonical intent shape, includes `key` when the inspection resolved one, and buckets intents by per-inspection target pabgb. Multi-target `targets[]` envelope when more than one pabgb is touched; legacy single-target shape otherwise (preserves backwards compat).

```python
target = (
    getattr(insp, "target_file", None)
    or getattr(insp, "game_file", None)
    or getattr(insp, "pabgb", None)
    or "iteminfo.pabgb"  # legacy default
)
intent = {"entry": insp.entry or "", "field": insp.field_path,
          "op": "set", "new": insp.new_value}
if (key := getattr(insp, "key", None)) is not None:
    intent["key"] = int(key)
```

## What stays the same

`bagspace.py` and `world.py::_dropset_export_field_json` use slightly non-canonical field names (`default_slots` instead of `default_slot_count`; `drops` element shape `{item_key, rates, ...}` instead of wire-faithful `list[].raw_at_120` etc.). DMM 1.3.5 pre-release.4+ accepts both via field aliases and a semantic-to-wire translation layer for `OptionalDropTarget`, so those exports work today. They're cosmetic — left alone in this PR to keep the diff focused on the actual blockers.

`buffs_v319.py` was the iteminfo-only export bug, fixed in #62.

`mercpets.py` and `skill_tree.py` v3 exports were already shape-correct.

## Test plan

- [x] `python -c "import ast; ast.parse(open('CrimsonGameMods/gui/tabs/reserveslot.py', encoding='utf-8').read())"` — clean
- [x] Same for `mod_loader.py` — clean
- [x] Field name `enable_vehicle_list` verified against `dmm-parser/src/tables/reserve_slot_info/info.rs` (line 71) and `field_aliases_v3_1.rs` (line 26)
- [x] Target stem `reserveslotinfo.pabgb` verified against dmm-parser's `normalize_pabgb_to_dispatch_name` (compressed form lookup → `reserve_slot_info`)
- [ ] Manual GUI run: edit a reserveslot, Export Field JSON, drop into DMM, mount, confirm `[V3_OVERLAY] reserveslotinfo.pabgb` line appears with "N of N intent(s) applied" — leaving for maintainer
- [ ] Same for a Stacker Inspector conversion of any non-iteminfo Format 1/2 mod — needs a real legacy mod to test against

## Compat notes

- Both fixes preserve backwards-compat with single-target loaders (legacy `target` shape used when only one pabgb is involved).
- Field name change in reserveslot (`_enableVehicleList` → `enable_vehicle_list`) is the canonical default emit. dmm-parser accepts both via the alias registry. Older loaders that only knew the legacy `_camelCase` name are unaffected because that's still accepted on input.
- Stacker Inspector's intent shape now matches what every other tab in this repo emits. No downstream consumer breakage expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)