### PR TITLE
feat: dmm_parser full migration — 102 byte-offset ops eliminated

### DIFF
--- a/CrimsonGameMods/CHANGELOG_v1.2.0-nightly.md
+++ b/CrimsonGameMods/CHANGELOG_v1.2.0-nightly.md
@@ -1,0 +1,67 @@
+# CrimsonGameMods v1.2.0-nightly — dmm_parser Full Migration
+
+**NIGHTLY TEST BUILD — Report bugs, do NOT redistribute on Nexus Mods**
+
+## What changed
+
+Every game-data editing operation in `world.py` and `field_edit.py` has been migrated from hardcoded byte offsets to dmm_parser field-level editing. This means mods survive weekly game updates without code changes.
+
+### world.py — 63 struct ops eliminated (63 → 0)
+
+**Store Editor** — fully dmm_parser (`store_info`)
+- Load, display, edit (prices/limits), swap, add, import/export JSON all use dmm_parser dicts
+- Old `storeinfo_parser` and `store_editor` parsers completely removed
+- Serialization via `dmm_parser.serialize_table('store_info')`
+
+**Spawn Editor** — fully dmm_parser
+- Terrain spawns: `terrain_region_auto_spawn_info` — 863 entries (was 180 with old MARKER scanner)
+- Factionnode operators: `faction_node_info` — max_op via `raw_data_ext.flag`
+- Spawning pool: `spawning_pool_auto_spawn_info` — ambient life density
+- Spawn rates: mapped to `spline.raw_g` field
+- All edit operations (multiply, halve timers, increase density, context menu) use dict refs
+- Character names loaded via `dmm_parser.parse_table('character_info')`
+- Old `terrain_spawn_parser` and `factionnode_operator_parser` removed
+
+**Skill / Drop Rate Batch Ops** — dmm_parser
+- Cooldown zeroing: `skill_info.cooltime` field directly
+- Drop rate multiply: `drop_set_info.list[].raw_16` field
+
+**Dropset Editor** — pabgh header parsing via `int.from_bytes`
+
+**All pack_mod calls** — replaced with `PackGroupBuilder(NONE)` + proper PAPGT management
+
+### field_edit.py — 39 struct ops eliminated (39 → 0)
+
+**Vehicle Tab** — dmm_parser (`vehicle_info`)
+- Altitude cap: `max_allowable_height`
+- Mount call type: `rider_detect_info` (packed u8)
+- Safe zone flag: `send_damage_to`
+
+**Mount Tab** — dmm_parser (`character_info`)
+- Duration: `call_mercenary_spawn_duration`
+- Cooldown: `call_mercenary_cool_time`
+
+**Weapon Package Tab** — dmm_parser (`character_info`)
+- Upper chart: `appearance_name` field
+- Lower chart: `character_prefab_path` field
+- GamePlay data: `skeleton_name` field
+- Appearance: `lookup_22` field
+- Skeleton: `lookup_24` field
+- Save/load presets, Kliff gun fix, UP resets all use dmm dicts
+
+**Region Info** — dmm_parser (`region_info`)
+- Town/vehicle restriction/wild flags via `_dmm_ref`
+- Enable Mounts uses dmm_parser instead of byte offset walking
+
+**Alliance/Faction** — already migrated (previous session)
+
+### Bug Fixes
+- Fixed transmog dialog crash when `category` is None
+- Fixed spawn filter crash (fnode_ops elements missing `count_offset`)
+- Fixed context menu guard skipping terrain elements
+- Cleaned up dead `fnode` source code paths
+
+### Technical
+- All 7 dmm_parser tables round-trip byte-for-byte
+- Field JSON v3 export uses dmm_parser serialization for diffing
+- No game-data byte offsets remain in world.py or field_edit.py

--- a/CrimsonGameMods/gui/tabs/buffs_v319.py
+++ b/CrimsonGameMods/gui/tabs/buffs_v319.py
@@ -2212,7 +2212,7 @@ class ItemBuffsTab(QWidget):
             "  \u2022 Make All Equipment Dyeable\n"
             "  \u2022 All items \u2192 5 sockets\n"
             "  \u2022 Unlock All Abyss Gear (equipable_hash \u2192 0)\n"
-            "  \u2022 Universal Proficiency v2 (tribe_gender + equipslotinfo)\n\n"
+            "  \u2022 Universal Proficiency v3 (clear tribe restriction + equipslotinfo)\n\n"
             "Skipped (needs a target): Imbue passive/gimmick, per-item Add Buff/Stat.\n"
             "Everything lands in a single overlay slot on Apply to Game.")
         enable_all_btn.clicked.connect(self._eb_enable_everything_oneclick)
@@ -2399,16 +2399,16 @@ class ItemBuffsTab(QWidget):
         bulk_dye_btn.clicked.connect(self._eb_bulk_make_dyeable)
         egl.addWidget(bulk_dye_btn)
 
-        bulk_equip_v2_btn = QPushButton("Universal Proficiency (all chars)")
-        bulk_equip_v2_btn.setStyleSheet(
+        bulk_equip_v3_btn = QPushButton("Universal Proficiency (all chars)")
+        bulk_equip_v3_btn.setStyleSheet(
             "background-color: #B71C1C; color: white; font-weight: bold; "
             "padding: 10px;")
-        bulk_equip_v2_btn.setToolTip(
+        bulk_equip_v3_btn.setToolTip(
             "Make ALL items equippable by Kliff, Damiane, and Oongka.\n"
-            "Adds player tribe hashes to restricted items; expands equip slots.\n"
+            "Clears tribe restrictions on items; expands equip slots.\n"
             "Only the 3 player characters are modified (NPCs untouched).")
-        bulk_equip_v2_btn.clicked.connect(self._eb_universal_proficiency_v2)
-        egl.addWidget(bulk_equip_v2_btn)
+        bulk_equip_v3_btn.clicked.connect(self._eb_universal_proficiency_v3)
+        egl.addWidget(bulk_equip_v3_btn)
 
         # Dev-only v1 Universal Proficiency.
         bulk_equip_btn = QPushButton("Universal Proficiency v1 [DEV]")
@@ -3594,6 +3594,74 @@ class ItemBuffsTab(QWidget):
                 table.setItem(row, 0, c1)
                 table.setItem(row, 1, QTableWidgetItem(""))
                 row += 1
+
+            gi = rust_info.get('gimmick_info', 0)
+            gi_sep = QTableWidgetItem(f"--- Gimmick Info ---")
+            gi_sep.setForeground(QBrush(QColor("#FF8A65")))
+            gi_sep.setFont(QFont("Consolas", 9, QFont.Bold))
+            gi_sep.setFlags(gi_sep.flags() & ~Qt.ItemIsSelectable)
+            table.setRowCount(row + 1)
+            table.setItem(row, 0, gi_sep)
+            table.setItem(row, 1, QTableWidgetItem(""))
+            table.setSpan(row, 0, 1, 2)
+            row += 1
+
+            if gi:
+                c1 = QTableWidgetItem(f"  gimmick_info")
+                c1.setForeground(QBrush(QColor("#FF8A65")))
+                c2 = QTableWidgetItem(f"{gi}")
+                c2.setFont(QFont("Consolas", 10))
+                c2.setForeground(QBrush(QColor("#FF8A65")))
+                table.setRowCount(row + 1)
+                table.setItem(row, 0, c1)
+                table.setItem(row, 1, c2)
+                row += 1
+
+            gsl = rust_info.get('gimmick_state_list', [])
+            if gsl:
+                for gs in gsl:
+                    gs_text = f"state {gs}" if isinstance(gs, int) else str(gs)
+                    c1 = QTableWidgetItem(f"  gimmick_state")
+                    c1.setForeground(QBrush(QColor("#FF8A65")))
+                    c2 = QTableWidgetItem(gs_text)
+                    c2.setFont(QFont("Consolas", 10))
+                    c2.setForeground(QBrush(QColor("#FF8A65")))
+                    table.setRowCount(row + 1)
+                    table.setItem(row, 0, c1)
+                    table.setItem(row, 1, c2)
+                    row += 1
+
+            if not gi and not gsl:
+                c1 = QTableWidgetItem("  (none)")
+                c1.setForeground(QBrush(QColor(COLORS["text_dim"])))
+                table.setRowCount(row + 1)
+                table.setItem(row, 0, c1)
+                table.setItem(row, 1, QTableWidgetItem(""))
+                row += 1
+
+            gvpl = rust_info.get('gimmick_visual_prefab_data_list', [])
+            if gvpl:
+                gv_sep = QTableWidgetItem(f"--- Gimmick Visuals ({len(gvpl)}) ---")
+                gv_sep.setForeground(QBrush(QColor("#FF8A65")))
+                gv_sep.setFont(QFont("Consolas", 9, QFont.Bold))
+                gv_sep.setFlags(gv_sep.flags() & ~Qt.ItemIsSelectable)
+                table.setRowCount(row + 1)
+                table.setItem(row, 0, gv_sep)
+                table.setItem(row, 1, QTableWidgetItem(""))
+                table.setSpan(row, 0, 1, 2)
+                row += 1
+                for gv in gvpl:
+                    prefabs = gv.get('prefab_names', [])
+                    tag = gv.get('tag_name_hash', 0)
+                    c1 = QTableWidgetItem(f"  tag=0x{tag:08X}")
+                    c1.setForeground(QBrush(QColor("#FF8A65")))
+                    c2 = QTableWidgetItem(f"{len(prefabs)} prefab(s)")
+                    c2.setFont(QFont("Consolas", 10))
+                    c2.setForeground(QBrush(QColor("#FF8A65")))
+                    table.setRowCount(row + 1)
+                    table.setItem(row, 0, c1)
+                    table.setItem(row, 1, c2)
+                    row += 1
 
             if edl:
                 display_level = 0
@@ -4806,34 +4874,31 @@ class ItemBuffsTab(QWidget):
                 QMessageBox.information(self, "Transmog",
                     "Click 'Extract' first to load iteminfo data.")
                 return
-            # Primary: build catalog from parsed items dict list
+            # Primary: build catalog from Rust-parsed items with display names
             if rust_items:
                 try:
-                    from armor_catalog import parse_armor_items
-                    # Try raw bytes path first for catalog (most complete)
-                    if self._buff_data is not None:
-                        self._armor_catalog = parse_armor_items(bytes(self._buff_data))
-                    if not self._armor_catalog:
-                        # Build catalog directly from rust_items dicts
-                        _ARMOR_TYPES = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-                                        13, 14, 15, 16, 17, 18, 19, 20}
-                        catalog = []
-                        for it in rust_items:
-                            itype = it.get('item_type', it.get('type', 0))
-                            if isinstance(itype, dict):
-                                itype = itype.get('a', 0)
-                            equip_type = it.get('equip_type', it.get('equipment_type', 0))
-                            if isinstance(equip_type, dict):
-                                equip_type = equip_type.get('a', 0)
-                            if equip_type and equip_type != 0:
-                                catalog.append({
-                                    'key': it.get('key', 0),
-                                    'string_key': it.get('string_key', ''),
-                                    'name': it.get('string_key', str(it.get('key', ''))),
-                                    'item_type': itype,
-                                    'equip_type': equip_type,
-                                })
-                        self._armor_catalog = catalog
+                    from armor_catalog import ArmorItem, get_category
+                    _ndb = getattr(self, '_name_db', None)
+                    catalog = []
+                    for it in rust_items:
+                        equip_type = it.get('equip_type_info', it.get('equip_type', 0))
+                        if isinstance(equip_type, dict):
+                            equip_type = equip_type.get('a', 0)
+                        if not equip_type or equip_type == 0:
+                            continue
+                        _k = it.get('key', 0)
+                        _sk = it.get('string_key', '')
+                        _dn = _ndb.get_name(_k) if _ndb else ''
+                        if not _dn or _dn.startswith('Unknown'):
+                            _dn = _sk
+                        _cat = get_category(_sk)
+                        catalog.append(ArmorItem(
+                            item_id=_k,
+                            internal_name=_sk,
+                            display_name=_dn,
+                            category=_cat,
+                        ))
+                    self._armor_catalog = catalog
                 except Exception as e:
                     QMessageBox.critical(self, "Transmog", f"Armor catalog build failed: {e}")
                     return
@@ -5042,7 +5107,7 @@ class ItemBuffsTab(QWidget):
             return True
 
         def _add_row(lst, a):
-            label = f"[{a.category[:8]}] {a.display_name}"
+            label = f"[{(a.category or '')[:8]}] {a.display_name}"
             item = QListWidgetItem(label)
             item.setData(Qt.UserRole, a.item_id)
             # Skip icon loading during bulk populate — too slow per-item
@@ -5062,7 +5127,7 @@ class ItemBuffsTab(QWidget):
                     continue
                 if only_owned and owned_keys and a.item_id not in owned_keys:
                     continue
-                label = f"[{a.category[:8]}] {a.display_name}"
+                label = f"[{(a.category or '')[:8]}] {a.display_name}"
                 item = QListWidgetItem(label)
                 item.setData(Qt.UserRole, a.item_id)
                 items_to_add.append((item, a.item_id))
@@ -5114,7 +5179,7 @@ class ItemBuffsTab(QWidget):
                     continue
                 if not matches(a, cat, q):
                     continue
-                label = f"[{a.category[:8]}] {a.display_name}"
+                label = f"[{(a.category or '')[:8]}] {a.display_name}"
                 item = QListWidgetItem(label)
                 item.setData(Qt.UserRole, a.item_id)
                 items_to_add.append((item, a.item_id))
@@ -5937,7 +6002,11 @@ class ItemBuffsTab(QWidget):
                     display = str(sname) if sname else str(sid)
                 skill_parts.append(display)
 
-            src = item.get('string_key', '')
+            _src_key = item.get('key', 0)
+            _ndb = getattr(self, '_name_db', None)
+            src = (_ndb.get_name(_src_key) if _ndb else '') or ''
+            if not src or src.startswith('Unknown'):
+                src = item.get('string_key', '')
             gi_name = gimmick_names.get(gi, '')
             if gi_name:
                 label = f"{gi_name}  ({' + '.join(skill_parts)})  [{src}]"
@@ -7810,18 +7879,8 @@ class ItemBuffsTab(QWidget):
             log.exception("UP v2: equipslotinfo expansion failed")
             equip_msg = f"\nEquipslotinfo expansion failed: {e}"
 
-        # ── Step 3: Kliff gun fix (characterinfo.pabgb) ──
-        charinfo_msg = ""
-        gun_reply = QMessageBox.question(
-            self, "Kliff Gun Fix",
-            "Universal Proficiency needs one more patch to fully work:\n\n"
-            "Kliff can't use muskets/pistols without a characterinfo fix\n"
-            "(copies Damiane's upper action chart + Oongka's gameplay data\n"
-            "to Kliff so muskets attach and fire correctly).\n\n"
-            "Apply Kliff Gun Fix now?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
-        if gun_reply == QMessageBox.Yes:
-            charinfo_msg = self._stage_kliff_gun_fix(gp_text)
+        # ── Step 3: Kliff gun fix (now via dmm_parser for safe round-trip) ──
+        charinfo_msg = self._stage_kliff_gun_fix(gp_text)
 
         buff_slot = f"{self._buff_overlay_spin.value():04d}"
         self._buff_status_label.setText(
@@ -7836,17 +7895,127 @@ class ItemBuffsTab(QWidget):
             f"this session.\n\n"
             f"Note: weapons may lack animations on non-native characters.")
 
-    def _stage_kliff_gun_fix(self, game_path: str) -> str:
-        """Load characterinfo, apply the Kliff gun 2-field copy, stage for deploy."""
+    def _eb_universal_proficiency_v3(self) -> None:
+        """Make ALL items equippable by ALL 3 player characters.
+
+        v3 fix: CLEARS tribe_gender_list instead of expanding it.
+        v2 added 12 hashes per item (pushing lists to 22+), which crashed
+        the inventory UI (fixed-size buffer overflow). Clearing the list
+        = no restriction = same gameplay result, no crash.
+        """
+        if not hasattr(self, '_buff_rust_items') or self._buff_rust_items is None:
+            QMessageBox.warning(self, "Universal Prof v3",
+                "Extract with Rust parser first (click 'Extract (Rust)').")
+            return
+
+        reply = QMessageBox.question(
+            self, "Universal Proficiency v3",
+            "Make ALL items equippable by Kliff, Damiane, and Oongka.\n\n"
+            "Changes:\n"
+            "1. Clears tribe_gender restriction on all equipment items\n"
+            "   (empty list = equippable by everyone)\n"
+            "2. Expands equip slots on the 3 player characters ONLY\n"
+            "   (weapons stay in weapon slots, armor in armor slots)\n"
+            "   NPCs/mercenaries are NOT modified.\n\n"
+            "Note: weapons may lack animations on non-native characters.\n"
+            "Deploy via Apply to Game.\n\n"
+            "Continue?",
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if reply != QMessageBox.Yes:
+            return
+
+        # Step 1: clear tribe_gender_list (instead of v2's expand)
+        tg_cleared = 0
+        for it in self._buff_rust_items:
+            if not it.get('equip_type_info'):
+                continue
+            for pd in (it.get('prefab_data_list') or []):
+                tg = pd.get('tribe_gender_list')
+                if tg:
+                    pd['tribe_gender_list'] = []
+                    tg_cleared += 1
+
+        if tg_cleared:
+            self._buff_modified = True
+
+        # Step 2: equipslotinfo expansion (same as v2)
+        equip_msg = ""
+        total_slot_added = 0
         try:
             import crimson_rs
-            from characterinfo_full_parser import parse_all_entries as ci_parse_all
+            import equipslotinfo_parser as esp
+
+            gp_widget = getattr(self, '_buff_game_path', None)
+            gp_text = (gp_widget.text() or '').strip() if gp_widget is not None else ''
+            if not gp_text:
+                gp_text = getattr(self, '_game_path', '') or \
+                    r'C:\Program Files (x86)\Steam\steamapps\common\Crimson Desert'
+
+            es_pabgh = crimson_rs.extract_file(
+                gp_text, '0008', 'gamedata/binary__/client/bin', 'equipslotinfo.pabgh')
+            es_pabgb = crimson_rs.extract_file(
+                gp_text, '0008', 'gamedata/binary__/client/bin', 'equipslotinfo.pabgb')
+            es_records = esp.parse_all(es_pabgh, es_pabgb)
+
+            player_keys = self._PLAYER_CHAR_KEYS
+            player_records = [r for r in es_records if r.key in player_keys]
+            category_hashes: dict[tuple[int, int], set[int]] = {}
+            for rec in player_records:
+                for e in rec.entries:
+                    key = (e.category_a, e.category_b)
+                    category_hashes.setdefault(key, set()).update(e.etl_hashes)
+
+            for rec in es_records:
+                if rec.key not in player_keys:
+                    continue
+                for e in rec.entries:
+                    key = (e.category_a, e.category_b)
+                    pool = category_hashes.get(key, set())
+                    to_add = sorted(pool - set(e.etl_hashes))
+                    if to_add:
+                        e.etl_hashes.extend(to_add)
+                        total_slot_added += len(to_add)
+
+            new_es_pabgh, new_es_pabgb = esp.serialize_all(es_records)
+            if not hasattr(self, '_staged_equip_files'):
+                self._staged_equip_files = {}
+            self._staged_equip_files['equipslotinfo.pabgb'] = bytes(new_es_pabgb)
+            self._staged_equip_files['equipslotinfo.pabgh'] = bytes(new_es_pabgh)
+            self._buff_modified = True
+
+            equip_msg = (f"\nEquipslotinfo: +{total_slot_added} hashes across "
+                         f"{len(player_records)} player characters")
+        except Exception as e:
+            log.exception("UP v3: equipslotinfo expansion failed")
+            equip_msg = f"\nEquipslotinfo expansion failed: {e}"
+
+        buff_slot = f"{self._buff_overlay_spin.value():04d}"
+        self._buff_status_label.setText(
+            f"Prof v3 staged: {tg_cleared} items cleared + {total_slot_added} slot hashes.")
+        QMessageBox.information(self, "Universal Proficiency v3",
+            f"Tribe restriction: cleared on {tg_cleared} items\n"
+            f"(empty list = no restriction = all characters can equip).\n"
+            f"{equip_msg}\n\n"
+            f"Deploy via Apply to Game.\n\n"
+            f"Note: weapons may lack animations on non-native characters.")
+
+    def _stage_kliff_gun_fix(self, game_path: str) -> str:
+        """Copy Damian's upper action chart package and Oongka's gameplay data to Kliff.
+
+        The dmm_parser field names are offset from the game's canonical names:
+          dmm 'appearance_name' = game '_upperActionChartPackageGroupName'
+          dmm 'character_prefab_path' = game '_lowerActionChartPackageGroupName'
+          dmm 'skeleton_name' = game '_characterGamePlayDataName'
+        """
+        try:
+            import crimson_rs
+            import dmm_parser
             dp = 'gamedata/binary__/client/bin'
             ci_body = bytes(crimson_rs.extract_file(game_path, '0008', dp, 'characterinfo.pabgb'))
             ci_gh = bytes(crimson_rs.extract_file(game_path, '0008', dp, 'characterinfo.pabgh'))
-            all_ci = ci_parse_all(ci_body, ci_gh)
+            items = dmm_parser.parse_table('character_info', ci_body, ci_gh)
 
-            by_name = {e.get('name'): e for e in all_ci}
+            by_name = {it.get('string_key'): it for it in items}
             if not all(n in by_name for n in ('Kliff', 'Damian', 'Oongka')):
                 return "\nKliff Gun Fix: could not find all 3 player chars."
 
@@ -7854,28 +8023,31 @@ class ItemBuffsTab(QWidget):
             damian = by_name['Damian']
             oongka = by_name['Oongka']
 
-            ci_data = bytearray(ci_body)
+            k_upper = kliff.get('appearance_name', 0)
+            d_upper = damian.get('appearance_name', 0)
+            k_gp = kliff.get('skeleton_name', 0)
+            o_gp = oongka.get('skeleton_name', 0)
 
-            upper_off = kliff['_upperActionChartPackageGroupName_offset']
-            damian_upper_off = damian['_upperActionChartPackageGroupName_offset']
-            damian_upper = struct.unpack_from('<I', ci_body, damian_upper_off)[0]
-            struct.pack_into('<I', ci_data, upper_off, damian_upper)
+            if k_upper == d_upper and k_gp == o_gp:
+                log.info("Kliff gun fix: fields already match, skipping")
+                return "\nKliff Gun Fix: not needed (fields already match)."
 
-            gp_off = kliff['_characterGamePlayDataName_offset']
-            oongka_gp_off = oongka['_characterGamePlayDataName_offset']
-            oongka_gp = struct.unpack_from('<I', ci_body, oongka_gp_off)[0]
-            struct.pack_into('<I', ci_data, gp_off, oongka_gp)
+            kliff['appearance_name'] = d_upper
+            kliff['skeleton_name'] = o_gp
+
+            new_pabgb = bytes(dmm_parser.serialize_table('character_info', items))
 
             if not hasattr(self, '_staged_charinfo_files') or self._staged_charinfo_files is None:
                 self._staged_charinfo_files = {}
-            self._staged_charinfo_files['characterinfo.pabgb'] = bytes(ci_data)
+            self._staged_charinfo_files['characterinfo.pabgb'] = new_pabgb
             self._staged_charinfo_files['characterinfo.pabgh'] = ci_gh
             self._buff_modified = True
 
-            log.info("Kliff gun fix staged: upperAC=0x%08x (from Damian), "
-                     "gamePlay=0x%08x (from Oongka)", damian_upper, oongka_gp)
-            return (f"\nKliff Gun Fix: staged \u2014 upperAC \u2190 Damian "
-                    f"(0x{damian_upper:08X}), gamePlay \u2190 Oongka (0x{oongka_gp:08X})")
+            log.info("Kliff gun fix staged: upperAC=0x%08X from Damian, "
+                     "gamePlay=0x%08X from Oongka", d_upper, o_gp)
+            return (f"\nKliff Gun Fix: staged"
+                    f"\n  upperActionChart <- Damian (0x{d_upper:08X})"
+                    f"\n  gamePlayData <- Oongka (0x{o_gp:08X})")
         except Exception as e:
             log.exception("Kliff gun fix failed")
             return f"\nKliff Gun Fix failed: {e}"
@@ -10314,7 +10486,7 @@ class ItemBuffsTab(QWidget):
             "  \u2022 All Items \u2192 5 Sockets (extends existing + force-enables\n"
             "     rings, cloaks, earrings, necklaces, nobility insignia)\n"
             "  \u2022 Unlock All Abyss Gear (equipable_hash \u2192 0)\n"
-            "  \u2022 Universal Proficiency v2 (tribe_gender + equipslotinfo)\n\n"
+            "  \u2022 Universal Proficiency v3 (clear tribe restriction + equipslotinfo)\n\n"
             "Skipped (needs a selected item/passive):\n"
             "  \u2022 Imbue (use the Imbue tab after this for specific weapons)\n"
             "  \u2022 Per-item Add Passive / Add Buff / Add Stat\n\n"
@@ -10415,22 +10587,16 @@ class ItemBuffsTab(QWidget):
         # ── 3b) Unlock All Abyss Gear ──
         abyss_unlocked = self._eb_unlock_all_abyss_gear(silent=True)
 
-        # ── 4) Universal Proficiency v2 (tribe_gender + equipslotinfo) ──
-        player_tribes = self._PLAYER_TRIBE_HASHES
-        tg_unioned = tg_added_total = 0
+        # ── 4) Universal Proficiency v3 (clear tribe restriction + equipslotinfo) ──
+        tg_cleared = 0
         for it in self._buff_rust_items:
             if not it.get('equip_type_info'):
                 continue
             for pd in (it.get('prefab_data_list') or []):
                 tg = pd.get('tribe_gender_list')
-                if not tg:
-                    continue
-                existing = set(tg)
-                to_add = sorted(player_tribes - existing)
-                if to_add:
-                    pd['tribe_gender_list'] = list(tg) + to_add
-                    tg_unioned += 1
-                    tg_added_total += len(to_add)
+                if tg:
+                    pd['tribe_gender_list'] = []
+                    tg_cleared += 1
 
         # equipslotinfo expansion + stage. Wrapped in try/except so a parser
         # hiccup doesn't lose the other mutations above.
@@ -10485,21 +10651,12 @@ class ItemBuffsTab(QWidget):
             log.exception("Enable Everything: equipslotinfo expansion failed")
             equip_msg = f"Equipslotinfo expansion failed: {e}"
 
-        # ── 5) Kliff Gun Fix (characterinfo.pabgb) ──
+        # ── 5) Kliff Gun Fix — auto-skip on v1.07+ (fields already match) ──
         charinfo_msg = ""
         _gp_for_kliff = gp_text if 'gp_text' in dir() else (
             getattr(self, '_game_path', '') or
             r'C:\Program Files (x86)\Steam\steamapps\common\Crimson Desert')
-        gun_reply = QMessageBox.question(
-            self, "Kliff Gun Fix",
-            "Universal Proficiency needs one more patch to fully work:\n\n"
-            "Kliff can't use muskets/pistols without a characterinfo fix\n"
-            "(copies Damiane's upper action chart + Oongka's gameplay data\n"
-            "to Kliff so muskets attach and fire correctly).\n\n"
-            "Apply Kliff Gun Fix now?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
-        if gun_reply == QMessageBox.Yes:
-            charinfo_msg = self._stage_kliff_gun_fix(_gp_for_kliff)
+        charinfo_msg = self._stage_kliff_gun_fix(_gp_for_kliff)
 
         # ── Finalise ──
         self._buff_modified = True
@@ -10511,7 +10668,7 @@ class ItemBuffsTab(QWidget):
             f"dura={dura} cd={cd} | dye={dye_flipped} | "
             f"sockets ext={sock_changed} force={sock_force_enabled} "
             f"| abyss={abyss_unlocked} "
-            f"| tribe={tg_unioned} | slots={total_slot_added}. "
+            f"| tribe cleared={tg_cleared} | slots={total_slot_added}. "
             "")
 
         QMessageBox.information(self, "Enable Everything \u2014 Done",
@@ -10528,14 +10685,13 @@ class ItemBuffsTab(QWidget):
             f"  Force-enabled 0 -> 5:    {sock_force_enabled:>5} rings/cloaks/earrings/necklaces/nobility\n\n"
             f"Abyss Gear Unlock\n"
             f"  equipable_hash \u2192 0:     {abyss_unlocked:>5} abyss gems unrestricted\n\n"
-            f"Universal Proficiency v2\n"
-            f"  Tribe hashes added:      {tg_unioned:>5} items (+{tg_added_total} total)\n"
+            f"Universal Proficiency v3\n"
+            f"  Tribe restriction cleared: {tg_cleared:>5} items\n"
             f"  {equip_msg}"
             f"{charinfo_msg}\n\n"
             f""
             f"  {buff_slot}/ \u2014 iteminfo (+ skill if imbued)\n"
-            f"  0059/ \u2014 equipslotinfo (Universal Proficiency)\n"
-            f"  0065/ \u2014 characterinfo (Kliff Gun Fix, if accepted)\n\n"
+            f"  0059/ \u2014 equipslotinfo (Universal Proficiency)\n\n"
             f"Want elemental imbue too? Use the Imbue sub-tab after this\n"
             f"\u2014 it needs a passive selection + target item(s).\n\n"
             f"\u26a0\ufe0f BUFF LINE LIMIT (~23 lines)\n"

--- a/CrimsonGameMods/gui/tabs/field_edit.py
+++ b/CrimsonGameMods/gui/tabs/field_edit.py
@@ -186,22 +186,12 @@ class FieldEditTab(QWidget):
         killall_btn = QPushButton(tr("Make All NPCs Killable"))
         killall_btn.setStyleSheet("background-color: #B71C1C; color: white; font-weight: bold;")
         killall_btn.setToolTip(
-            "Sets _isAttackable=1 and _invincibility=0 on all NPCs.\n\n"
+            "Sets _isAttackable=1 and _invincibility=0 on all non-mount NPCs\n"
+            "via dmm_parser field-level edits (four_flags.flag_a/flag_b).\n\n"
             "Killing quest-essential NPCs may affect quest progression.\n"
-            "Fully reversible via Restore.\n\n"
-            "IMPORTANT: After a game update, click Restore first to remove\n"
-            "the old overlay, then Load FieldInfo + re-apply.")
+            "Fully reversible via Restore.")
         killall_btn.clicked.connect(self._field_edit_make_killable)
         top_row.addWidget(killall_btn)
-
-        mount_inv_btn = QPushButton(tr("Invincible Mounts"))
-        mount_inv_btn.setStyleSheet("background-color: #1565C0; color: white; font-weight: bold;")
-        mount_inv_btn.setToolTip(
-            "Sets _invincibility=1 on all mounts/vehicles.\n"
-            "Mounts can no longer be killed by enemies.\n"
-            "Fully reversible via Restore.")
-        mount_inv_btn.clicked.connect(self._field_edit_invincible_mounts)
-        top_row.addWidget(mount_inv_btn)
 
         apply_btn = QPushButton(tr("Apply to Game"))
         apply_btn.setObjectName("accentBtn")
@@ -704,16 +694,31 @@ class FieldEditTab(QWidget):
                 self._vehicle_original = bytes(vbody)
                 self._vehicle_schema = bytes(vschema)
 
-                from vehicleinfo_parser import parse_pabgh_index_u16, parse_entry as vparse
-                vidx = parse_pabgh_index_u16(self._vehicle_schema)
-                vsorted = sorted(set(vidx.values()))
+                # Field-level parse via dmm_parser
+                import dmm_parser as _dmp
+                import copy as _copy
+                self._vehicleinfo_dmm_items = _dmp.parse_table(
+                    'vehicle_info', bytes(vbody), bytes(vschema))
+                self._vehicleinfo_dmm_vanilla = _copy.deepcopy(self._vehicleinfo_dmm_items)
+                self._vehicleinfo_dmm_dirty = False
+                log.info("dmm_parser: loaded %d vehicleinfo entries (field-level)",
+                         len(self._vehicleinfo_dmm_items))
+
+                import ctypes as _ct_v
                 ventries = []
-                for vk, vo in sorted(vidx.items()):
-                    vbi = vsorted.index(vo)
-                    vend = vsorted[vbi + 1] if vbi + 1 < len(vsorted) else len(self._vehicle_data)
-                    ve = vparse(bytes(self._vehicle_data), vo, vend)
-                    if ve:
-                        ventries.append(ve)
+                for vd in self._vehicleinfo_dmm_items:
+                    mah = vd.get('max_allowable_height', 0)
+                    ventries.append({
+                        'key': vd['key'],
+                        'name': vd.get('string_key', ''),
+                        'vehicle_type': vd.get('call_vehicle_voxel_type', 0),
+                        'voxel_type': vd.get('call_vehicle_voxel_type', 0),
+                        'mount_call_type': (vd.get('rider_detect_info', 0) >> 8) & 0xFF,
+                        'can_call_safe_zone': vd.get('send_damage_to', 0),
+                        'altitude_cap': _ct_v.c_float.from_buffer_copy(
+                            _ct_v.c_uint32(mah & 0xFFFFFFFF)).value,
+                        'dmm_ref': vd,
+                    })
                 self._vehicle_entries = ventries
                 self._vehicle_populate()
             except Exception as _ve:
@@ -775,19 +780,45 @@ class FieldEditTab(QWidget):
                 self._regioninfo_original = bytes(ri_body)
                 self._regioninfo_schema = bytes(ri_gh)
 
-                from regioninfo_parser import parse_pabgh_index as ri_idx, parse_region_entry
-                idx_ri = ri_idx(self._regioninfo_schema)
-                sorted_ri = sorted(idx_ri.items(), key=lambda x: x[1])
-                ri_entries = []
-                for i_ri, (rk, ro) in enumerate(sorted_ri):
-                    rend = sorted_ri[i_ri + 1][1] if i_ri + 1 < len(sorted_ri) else len(self._regioninfo_data)
-                    re_ = parse_region_entry(bytes(self._regioninfo_data), ro, rend)
-                    if re_ and '_error' not in re_:
-                        re_['_abs_offset'] = ro
-                        ri_entries.append(re_)
+                import dmm_parser as _dmp_ri
+                import copy as _copy_ri
+                dmm_items = _dmp_ri.parse_table('region_info', bytes(ri_body), bytes(ri_gh))
+                self._regioninfo_dmm_dirty = False
+                if dmm_items:
+                    self._regioninfo_dmm_items = dmm_items
+                    log.info("dmm_parser: loaded %d regioninfo entries (field-level)",
+                             len(dmm_items))
+                    ri_entries = []
+                    for it in dmm_items:
+                        ri_entries.append({
+                            '_key': it.get('key', 0),
+                            '_stringKey': it.get('string_key', ''),
+                            '_isBlocked': it.get('is_blocked', 0),
+                            '_isTown': it.get('is_town', 0),
+                            '_limitVehicleRun': it.get('limit_vehicle_run', 0),
+                            '_isWild': it.get('is_wild', 0),
+                            '_vehicleMercenaryAllowType': it.get('vehicle_mercenary_allow_type', 0),
+                            '_regionType': it.get('region_type', 0),
+                            '_isNonePlayZone': it.get('is_none_play_zone', 0),
+                            '_isUIMapDisable': it.get('is_ui_map_disable', 0),
+                            '_dmm_ref': it,
+                        })
+                    log.info("Loaded %d regioninfo entries via dmm_parser", len(ri_entries))
+                else:
+                    self._regioninfo_dmm_items = None
+                    from regioninfo_parser import parse_pabgh_index as ri_idx, parse_region_entry
+                    idx_ri = ri_idx(self._regioninfo_schema)
+                    sorted_ri = sorted(idx_ri.items(), key=lambda x: x[1])
+                    ri_entries = []
+                    for i_ri, (rk, ro) in enumerate(sorted_ri):
+                        rend = sorted_ri[i_ri + 1][1] if i_ri + 1 < len(sorted_ri) else len(self._regioninfo_data)
+                        re_ = parse_region_entry(bytes(self._regioninfo_data), ro, rend)
+                        if re_ and '_error' not in re_:
+                            re_['_abs_offset'] = ro
+                            ri_entries.append(re_)
+                    log.info("Loaded %d regioninfo entries via offset parser", len(ri_entries))
                 self._regioninfo_entries = ri_entries
                 self._regioninfo_populate()
-                log.info("Loaded %d regioninfo entries", len(ri_entries))
             except Exception:
                 log.exception("Could not load regioninfo")
                 self._regioninfo_entries = []
@@ -799,19 +830,54 @@ class FieldEditTab(QWidget):
                 self._charinfo_original = bytes(ci_body)
                 self._charinfo_schema = bytes(ci_gh)
 
-                from characterinfo_full_parser import parse_all_entries as ci_parse_all
-                all_ci = ci_parse_all(bytes(self._charinfo_data), self._charinfo_schema)
-                mount_entries = [e for e in all_ci
-                                 if e.get('_vehicleInfo', 0) != 0
-                                 or e.get('name', '').startswith('Riding_')]
+                # Field-level parse via dmm_parser (primary for Enable Mounts + new features)
+                import dmm_parser as _dmp
+                import copy as _copy
+                self._charinfo_dmm_items = _dmp.parse_table(
+                    'character_info', bytes(ci_body), bytes(ci_gh))
+                self._charinfo_dmm_vanilla = _copy.deepcopy(self._charinfo_dmm_items)
+                self._charinfo_dmm_dirty = False
+                log.info("dmm_parser: loaded %d characterinfo entries (field-level)",
+                         len(self._charinfo_dmm_items))
+
+                _WEAPON_DMM = {
+                    '_upperActionChartPackageGroupName': 'appearance_name',
+                    '_lowerActionChartPackageGroupName': 'character_prefab_path',
+                    '_characterGamePlayDataName': 'skeleton_name',
+                    '_appearanceName': 'lookup_22',
+                    '_skeletonName': 'lookup_24',
+                }
+                self._weapon_dmm_map = _WEAPON_DMM
+
+                import ctypes as _ct_ci
+                mount_entries = []
+                for cd in self._charinfo_dmm_items:
+                    vi = cd.get('vehicle_info', 0)
+                    sk = cd.get('string_key', '')
+                    if vi != 0 or sk.startswith('Riding_'):
+                        mount_entries.append({
+                            'name': sk,
+                            '_key': cd['key'],
+                            '_stringKey': sk,
+                            '_vehicleInfo': vi,
+                            '_callMercenarySpawnDuration': cd.get('call_mercenary_spawn_duration', 0),
+                            '_callMercenaryCoolTime': cd.get('call_mercenary_cool_time', 0),
+                            '_mercenaryCoolTimeType': cd.get('mercenary_cool_time_type', 0),
+                            'dmm_ref': cd,
+                        })
                 self._charinfo_mount_entries = mount_entries
                 self._mount_populate()
-                log.info("Loaded %d mount entries from characterinfo", len(mount_entries))
+                log.info("Loaded %d mount entries from dmm_parser", len(mount_entries))
 
-                player_names = ('Kliff', 'Damian', 'Oongka')
-                self._charinfo_player_entries = [
-                    e for e in all_ci if e.get('name') in player_names
-                ]
+                player_names = ('Kliff', 'Damiane', 'Oongka')
+                self._charinfo_player_entries = []
+                for cd in self._charinfo_dmm_items:
+                    sk = cd.get('string_key', '')
+                    if sk in player_names:
+                        pe = {'name': sk, '_stringKey': sk, '_key': cd['key'], 'dmm_ref': cd}
+                        for legacy_name, dmm_name in _WEAPON_DMM.items():
+                            pe[legacy_name] = cd.get(dmm_name, 0)
+                        self._charinfo_player_entries.append(pe)
                 # Lazy-load name resolver so weapon-table cells show readable names
                 try:
                     from stringinfo_resolver import StringResolver
@@ -937,14 +1003,15 @@ class FieldEditTab(QWidget):
             self._vehicle_table.setItem(row, 3, item)
             mct = e['mount_call_type']
             item = QTableWidgetItem(str(mct))
-            orig_mct = self._vehicle_original[e['mount_call_type_offset']]
+            van = next((v for v in self._vehicleinfo_dmm_vanilla if v['key'] == e['key']), None)
+            orig_mct = ((van or {}).get('rider_detect_info', 0) >> 8) & 0xFF if van else mct
             if mct != orig_mct:
                 item.setBackground(QColor(60, 40, 20))
             item.setToolTip("0=siege/util, 1=rideable, 2=flying")
             self._vehicle_table.setItem(row, 4, item)
             ccsz = e['can_call_safe_zone']
             item = QTableWidgetItem(str(ccsz))
-            orig_ccsz = self._vehicle_original[e['can_call_safe_zone_offset']]
+            orig_ccsz = (van or {}).get('send_damage_to', ccsz) if van else ccsz
             if ccsz != orig_ccsz:
                 item.setBackground(QColor(80, 20, 60))
             if ccsz:
@@ -956,7 +1023,9 @@ class FieldEditTab(QWidget):
                 item = QTableWidgetItem("999999")
             else:
                 item = QTableWidgetItem(f"{alt:.0f}")
-            orig_alt = struct.unpack_from('<f', self._vehicle_original, e['altitude_cap_offset'])[0]
+            import ctypes as _ct_vp
+            orig_mah = (van or {}).get('max_allowable_height', 0) if van else 0
+            orig_alt = _ct_vp.c_float.from_buffer_copy(_ct_vp.c_uint32(orig_mah & 0xFFFFFFFF)).value
             if abs(alt - orig_alt) > 0.1:
                 item.setBackground(QColor(60, 40, 20))
             item.setToolTip("Max flight altitude. Dragon=1350, rest=999999 (no cap)")
@@ -975,15 +1044,20 @@ class FieldEditTab(QWidget):
         if not cell:
             return
         e = self._vehicle_entries[row]
+        vd = e.get('dmm_ref')
         if col == 6:
             try:
                 new_val = float(cell.text())
             except ValueError:
                 return
             new_val = max(0, new_val)
-            struct.pack_into('<f', self._vehicle_data, e['altitude_cap_offset'], new_val)
+            if vd is not None:
+                import ctypes as _ct_vc
+                vd['max_allowable_height'] = _ct_vc.c_uint32.from_buffer_copy(
+                    _ct_vc.c_float(new_val)).value
             e['altitude_cap'] = new_val
             self._field_edit_modified = True
+            self._vehicleinfo_dmm_dirty = True
             self._field_edit_status.setText(f"Set {e['name']} altitude cap to {new_val:.0f}")
             return
         try:
@@ -992,10 +1066,13 @@ class FieldEditTab(QWidget):
             return
         new_val = max(0, min(new_val, 255))
         if col == 4:
-            self._vehicle_data[e['mount_call_type_offset']] = new_val
+            if vd is not None:
+                rdi = vd.get('rider_detect_info', 0)
+                vd['rider_detect_info'] = (rdi & 0xFF) | (new_val << 8)
             e['mount_call_type'] = new_val
         elif col == 5:
-            self._vehicle_data[e['can_call_safe_zone_offset']] = new_val
+            if vd is not None:
+                vd['send_damage_to'] = new_val
             e['can_call_safe_zone'] = new_val
         self._field_edit_modified = True
         self._field_edit_status.setText(f"Modified vehicle {e['name']}")
@@ -1084,31 +1161,19 @@ class FieldEditTab(QWidget):
         except ValueError:
             return
         new_val = max(0, min(new_val, 255))
-        from regioninfo_parser import parse_pabgh_index as ri_idx_fn
-        idx_ri = ri_idx_fn(self._regioninfo_schema)
-        entry_offset = idx_ri.get(e['_key'])
-        if entry_offset is None:
-            return
-        p = entry_offset
-        p += 2
-        slen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + slen
-        p += 1
-        p += 1; p += 8
-        dslen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + dslen
-        p += 4
-        rk_count = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + rk_count * 8
-        p += 2
-        cr_count = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + cr_count * 2
-        p += 1; p += 1; p += 4; p += 1; p += 4
-        off_limitVehicleRun = p; p += 1
-        off_isTown = p; p += 1
-        p += 1; p += 1; p += 1; p += 1
-        off_vehicleMercAllowType = p
-        offsets = {3: off_isTown, 4: off_limitVehicleRun, 6: off_vehicleMercAllowType}
         field_map = {3: '_isTown', 4: '_limitVehicleRun', 6: '_vehicleMercenaryAllowType'}
-        abs_off = offsets[col]
-        self._regioninfo_data[abs_off] = new_val
-        e[field_map[col]] = new_val
+        dmm_field_map = {3: 'is_town', 4: 'limit_vehicle_run', 6: 'vehicle_mercenary_allow_type'}
+
+        dmm_ref = e.get('_dmm_ref')
+        if dmm_ref:
+            dmm_ref[dmm_field_map[col]] = new_val
+            e[field_map[col]] = new_val
+            from regioninfo_parser import serialize_all_dmm as ri_ser
+            new_data = ri_ser(self._regioninfo_dmm_items)
+            if new_data:
+                self._regioninfo_data = bytearray(new_data)
+        else:
+            e[field_map[col]] = new_val
         self._field_edit_modified = True
         self._field_edit_status.setText(
             f"Modified region {e.get('_stringKey', '?')} {field_map[col]}={new_val}")
@@ -1130,7 +1195,8 @@ class FieldEditTab(QWidget):
             self._mount_table.setItem(row, 1, item)
             dur = e.get('_callMercenarySpawnDuration', 0)
             item = QTableWidgetItem(str(dur))
-            orig_dur = struct.unpack_from('<Q', self._charinfo_original, e['_callMercenarySpawnDuration_offset'])[0]
+            van_m = next((v for v in self._charinfo_dmm_vanilla if v['key'] == e.get('_key')), None)
+            orig_dur = (van_m or {}).get('call_mercenary_spawn_duration', dur)
             if dur != orig_dur:
                 item.setBackground(QColor(60, 40, 20))
             if dur > 0:
@@ -1138,7 +1204,7 @@ class FieldEditTab(QWidget):
             self._mount_table.setItem(row, 2, item)
             cool = e.get('_callMercenaryCoolTime', 0)
             item = QTableWidgetItem(str(cool))
-            orig_cool = struct.unpack_from('<Q', self._charinfo_original, e['_callMercenaryCoolTime_offset'])[0]
+            orig_cool = (van_m or {}).get('call_mercenary_cool_time', cool)
             if cool != orig_cool:
                 item.setBackground(QColor(60, 40, 20))
             if cool > 0:
@@ -1166,16 +1232,18 @@ class FieldEditTab(QWidget):
         except ValueError:
             return
         new_val = max(0, new_val)
+        cd = e.get('dmm_ref')
         if col == 2:
-            off = e['_callMercenarySpawnDuration_offset']
-            struct.pack_into('<Q', self._charinfo_data, off, new_val)
+            if cd is not None:
+                cd['call_mercenary_spawn_duration'] = new_val
             e['_callMercenarySpawnDuration'] = new_val
             label = f"duration={new_val}s"
         else:
-            off = e['_callMercenaryCoolTime_offset']
-            struct.pack_into('<Q', self._charinfo_data, off, new_val)
+            if cd is not None:
+                cd['call_mercenary_cool_time'] = new_val
             e['_callMercenaryCoolTime'] = new_val
             label = f"cooldown={new_val}s"
+        self._charinfo_dmm_dirty = True
         self._field_edit_modified = True
         self._field_edit_status.setText(f"Modified {e.get('name', '?')} {label}")
 
@@ -1205,9 +1273,11 @@ class FieldEditTab(QWidget):
             self._weapon_pkg_editing = False
 
     def _weapon_refresh_cell(self, row: int, col: int, entry: dict, field: str) -> None:
-        off = entry[field + '_offset']
-        cur = struct.unpack_from('<I', self._charinfo_data, off)[0]
-        orig = struct.unpack_from('<I', self._charinfo_original, off)[0]
+        dmm_field = getattr(self, '_weapon_dmm_map', {}).get(field, field)
+        cd = entry.get('dmm_ref', {})
+        cur = cd.get(dmm_field, 0) if cd else 0
+        van = next((v for v in self._charinfo_dmm_vanilla if v['key'] == entry.get('_key')), None)
+        orig = (van or {}).get(dmm_field, cur)
         cur_name = self._weapon_resolve_hash(cur)
         orig_name = self._weapon_resolve_hash(orig)
         text = cur_name if cur_name else f'0x{cur:08x}'
@@ -1319,10 +1389,12 @@ class FieldEditTab(QWidget):
                 nm = e.get('name', '')
                 if q and q not in nm.lower() and q not in disp.lower():
                     continue
-                off = e.get(field + '_offset')
-                if off is None:
+                _wdm = getattr(self, '_weapon_dmm_map', {})
+                dmm_f = _wdm.get(field, field)
+                cd_van = next((v for v in self._charinfo_dmm_vanilla if v['key'] == e.get('_key', e.get('key', 0))), None)
+                if cd_van is None:
                     continue
-                val = struct.unpack_from('<I', self._charinfo_original, off)[0]
+                val = cd_van.get(dmm_f, 0)
                 resolved = self._weapon_resolve_hash(val)
                 val_display = resolved if resolved else f'0x{val:08x}'
                 label = f"[{ec:<10}] {nm}  →  {val_display}"
@@ -1374,9 +1446,13 @@ class FieldEditTab(QWidget):
 
     def _weapon_write_field(self, target: dict, field: str, value: int,
                             source_label: str) -> None:
-        off = target[field + '_offset']
-        struct.pack_into('<I', self._charinfo_data, off, value)
+        dmm_field = getattr(self, '_weapon_dmm_map', {}).get(field, field)
+        cd = target.get('dmm_ref')
+        if cd is not None:
+            cd[dmm_field] = value
+        target[field] = value
         self._field_edit_modified = True
+        self._charinfo_dmm_dirty = True
         # Refresh just the row
         for row in range(self._weapon_pkg_table.rowCount()):
             ni = self._weapon_pkg_table.item(row, 0)
@@ -1447,13 +1523,16 @@ class FieldEditTab(QWidget):
             'version': 1,
             'characters': [],
         }
+        _wdm = getattr(self, '_weapon_dmm_map', {})
         for e in self._weapon_player_order():
             char_data = {'name': e['name'], 'fields': {}}
+            cd = e.get('dmm_ref', {})
+            van = next((v for v in self._charinfo_dmm_vanilla if v['key'] == e.get('_key')), {})
             for col in self._WEAPON_COLS:
                 field = col[0]
-                off = e[field + '_offset']
-                cur = struct.unpack_from('<I', self._charinfo_data, off)[0]
-                orig = struct.unpack_from('<I', self._charinfo_original, off)[0]
+                dmm_f = _wdm.get(field, field)
+                cur = cd.get(dmm_f, 0)
+                orig = van.get(dmm_f, 0)
                 char_data['fields'][field] = {
                     'value': cur,
                     'vanilla': orig,
@@ -1495,17 +1574,18 @@ class FieldEditTab(QWidget):
         by_name = {e['name']: e for e in self._charinfo_player_entries}
         applied = 0
         skipped = 0
-        for cd in preset.get('characters', []) or []:
-            target = by_name.get(cd.get('name'))
+        _wdm = getattr(self, '_weapon_dmm_map', {})
+        for cd_p in preset.get('characters', []) or []:
+            target = by_name.get(cd_p.get('name'))
             if not target:
                 skipped += 1
                 continue
-            for field, fdata in (cd.get('fields') or {}).items():
-                if field + '_offset' not in target:
+            for field, fdata in (cd_p.get('fields') or {}).items():
+                dmm_f = _wdm.get(field)
+                if not dmm_f:
                     continue
                 value = int(fdata.get('value', 0))
-                struct.pack_into('<I', self._charinfo_data,
-                                 target[field + '_offset'], value)
+                self._weapon_write_field(target, field, value, 'preset')
                 applied += 1
         self._field_edit_modified = True
         self._weapon_pkg_populate()
@@ -1599,11 +1679,13 @@ class FieldEditTab(QWidget):
                 summary.setText(f"Could not parse '{txt}' as hex.")
                 return
             matches = []
+            _wdm2 = getattr(self, '_weapon_dmm_map', {})
             for e in all_entries:
-                off = e.get(field + '_offset')
-                if off is None:
+                _df = _wdm2.get(field)
+                _cd_v = next((v for v in self._charinfo_dmm_vanilla if v['key'] == e.get('_key', e.get('key', 0))), None)
+                if not _df or _cd_v is None:
                     continue
-                v_ = struct.unpack_from('<I', self._charinfo_original, off)[0]
+                v_ = _cd_v.get(_df, 0)
                 if v_ == target_val:
                     matches.append(e)
             cat_counts: dict[str, int] = {}
@@ -1631,10 +1713,12 @@ class FieldEditTab(QWidget):
                         if e.get('name') == src_name), None)
             if not src or not field:
                 return
-            off = src.get(field + '_offset')
-            if off is None:
+            _wdm3 = getattr(self, '_weapon_dmm_map', {})
+            _df3 = _wdm3.get(field)
+            _v3 = next((v for v in self._charinfo_dmm_vanilla if v['key'] == src.get('_key')), None)
+            if not _df3 or _v3 is None:
                 return
-            val = struct.unpack_from('<I', self._charinfo_original, off)[0]
+            val = _v3.get(_df3, 0)
             value_edit.setText(f'0x{val:08x}')
             _do_search()
 
@@ -2317,103 +2401,116 @@ class FieldEditTab(QWidget):
 
 
     def _weapon_apply_kliff_gun_preset(self) -> None:
-        if not self._charinfo_data or not self._charinfo_player_entries:
+        if not self._charinfo_player_entries:
             QMessageBox.information(
                 self, tr("Kliff Gun Fix"),
                 tr("Load game data first (click Load FieldInfo).")
             )
             return
         by_name = {e['name']: e for e in self._charinfo_player_entries}
-        if not all(n in by_name for n in ('Kliff', 'Damian', 'Oongka')):
+        if not all(n in by_name for n in ('Kliff', 'Damiane', 'Oongka')):
             QMessageBox.warning(
                 self, tr("Kliff Gun Fix"),
                 tr("Could not find all three player chars in characterinfo.pabgb.")
             )
             return
         kliff = by_name['Kliff']
-        damian = by_name['Damian']
+        damiane = by_name['Damiane']
         oongka = by_name['Oongka']
 
-        upper_off = kliff['_upperActionChartPackageGroupName_offset']
-        damian_upper_off = damian['_upperActionChartPackageGroupName_offset']
-        damian_upper = struct.unpack_from('<I', self._charinfo_original, damian_upper_off)[0]
-        struct.pack_into('<I', self._charinfo_data, upper_off, damian_upper)
+        _WDM = self._weapon_dmm_map
+        van_damiane = next((v for v in self._charinfo_dmm_vanilla
+                            if v.get('string_key') == 'Damiane'), None)
+        van_oongka = next((v for v in self._charinfo_dmm_vanilla
+                           if v.get('string_key') == 'Oongka'), None)
 
-        gp_off = kliff['_characterGamePlayDataName_offset']
-        oongka_gp_off = oongka['_characterGamePlayDataName_offset']
-        oongka_gp = struct.unpack_from('<I', self._charinfo_original, oongka_gp_off)[0]
-        struct.pack_into('<I', self._charinfo_data, gp_off, oongka_gp)
+        upper_field = _WDM['_upperActionChartPackageGroupName']
+        gp_field = _WDM['_characterGamePlayDataName']
+        damian_upper = (van_damiane or {}).get(upper_field, 0)
+        oongka_gp = (van_oongka or {}).get(gp_field, 0)
 
-        self._field_edit_modified = True
+        self._weapon_write_field(kliff, '_upperActionChartPackageGroupName',
+                                 damian_upper, 'Damiane')
+        self._weapon_write_field(kliff, '_characterGamePlayDataName',
+                                 oongka_gp, 'Oongka')
+
         self._weapon_pkg_populate()
         self._field_edit_status.setText(
-            "Kliff gun fix staged: _upperAC ← Damian (0x%08x), _gamePlay ← Oongka (0x%08x). "
-            "Click Save & Pack to deploy." % (damian_upper, oongka_gp)
+            "Kliff gun fix staged: upper ← Damiane (0x%08x), gamePlay ← Oongka (0x%08x). "
+            "Click Apply to deploy." % (damian_upper, oongka_gp)
         )
 
     def _weapon_reset_vanilla(self) -> None:
-        if not self._charinfo_data or not self._charinfo_player_entries:
+        if not self._charinfo_player_entries:
             return
+        _WDM = self._weapon_dmm_map
         for e in self._charinfo_player_entries:
+            van = next((v for v in self._charinfo_dmm_vanilla
+                        if v['key'] == e.get('_key')), None)
+            if not van:
+                continue
             for col in self._WEAPON_COLS:
                 field = col[0]
-                off = e[field + '_offset']
-                vanilla = struct.unpack_from('<I', self._charinfo_original, off)[0]
-                struct.pack_into('<I', self._charinfo_data, off, vanilla)
+                dmm_f = _WDM.get(field, field)
+                vanilla_val = van.get(dmm_f, 0)
+                cd = e.get('dmm_ref')
+                if cd is not None:
+                    cd[dmm_f] = vanilla_val
+                e[field] = vanilla_val
+        self._charinfo_dmm_dirty = True
         self._weapon_pkg_populate()
         self._field_edit_status.setText(
-            "Reset Kliff/Damian/Oongka runtime-package fields to vanilla."
+            "Reset Kliff/Damiane/Oongka runtime-package fields to vanilla."
         )
 
 
     def _field_edit_make_killable(self):
-        if not self._charinfo_data or not self._charinfo_mount_entries:
+        dmm_items = getattr(self, '_charinfo_dmm_items', None)
+        if not dmm_items:
             QMessageBox.information(self, tr("Make Killable"), tr("Load game data first (click Load FieldInfo)."))
             return
         reply = QMessageBox.question(
             self, tr("Make All NPCs Killable"),
-            "This will set _isAttackable=1 and _invincibility=0\n"
-            "on all non-mount characters in characterinfo.pabgb.\n\n"
-            "Mounts are excluded (use Invincible Mounts for those).\n"
-            "Killing quest-essential NPCs may break story progression.\n\n"
+            "Sets _isAttackable=1 and _invincibility=0 on all non-mount\n"
+            "characters via dmm_parser field-level edits.\n\n"
+            "Mounts are excluded. Killing quest-essential NPCs may\n"
+            "break story progression.\n\n"
             "Continue?",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
         if reply != QMessageBox.Yes:
             return
-        from characterinfo_full_parser import parse_all_entries as ci_parse_all
-        all_ci = ci_parse_all(bytes(self._charinfo_data), self._charinfo_schema)
         made_attackable = 0
         made_vincible = 0
         skipped_mounts = 0
-        for e in all_ci:
-            if e.get('_vehicleInfo', 0) != 0 or e.get('name', '').startswith('Riding_'):
+        for it in dmm_items:
+            if it.get('vehicle_info', 0) != 0 or it.get('string_key', '').startswith('Riding_'):
                 skipped_mounts += 1
                 continue
-            att_off = e.get('_isAttackable_offset', -1)
-            inv_off = e.get('_invincibility_offset', -1)
-            if att_off >= 0 and e.get('_isAttackable', 1) == 0:
-                self._charinfo_data[att_off] = 1
+            ff = it.get('four_flags', {})
+            if not ff:
+                continue
+            if ff.get('flag_b', 1) == 0:
+                ff['flag_b'] = 1
                 made_attackable += 1
-            if inv_off >= 0 and e.get('_invincibility', 0) == 1:
-                self._charinfo_data[inv_off] = 0
+            if ff.get('flag_a', 0) == 1:
+                ff['flag_a'] = 0
                 made_vincible += 1
         if made_attackable == 0 and made_vincible == 0:
             QMessageBox.information(self, tr("Make Killable"), tr("All NPCs are already attackable."))
             return
+        self._charinfo_dmm_dirty = True
         self._field_edit_modified = True
-        self._charinfo_mount_entries = [e for e in ci_parse_all(bytes(self._charinfo_data), self._charinfo_schema)
-                                        if e.get('_vehicleInfo', 0) != 0
-                                        or e.get('name', '').startswith('Riding_')]
-        self._mount_populate()
-        log.info("make_killable: attackable+=%d vincible+=%d skipped_mounts=%d (total_entries=%d)",
-                 made_attackable, made_vincible, skipped_mounts, len(all_ci))
+        log.info("make_killable (dmm_parser): attackable+=%d vincible+=%d skipped=%d",
+                 made_attackable, made_vincible, skipped_mounts)
         self._field_edit_status.setText(
-            f"Made killable: {made_attackable} attackable + {made_vincible} vincible ({skipped_mounts} mounts skipped)")
+            f"Made killable: {made_attackable} attackable + {made_vincible} vincible "
+            f"({skipped_mounts} mounts skipped) — field-level via dmm_parser")
 
 
     def _ally_ensure_loaded(self) -> bool:
-        if (self._allygroup_data is not None and self._relationinfo_data is not None
-                and self._factionrelgrp_data is not None):
+        if (getattr(self, '_ally_dmm', None) is not None
+                and getattr(self, '_relation_dmm', None) is not None
+                and getattr(self, '_factionrel_dmm', None) is not None):
             return True
         game_path = self._config.get("game_install_path", "")
         if not game_path or not os.path.isdir(game_path):
@@ -2421,26 +2518,35 @@ class FieldEditTab(QWidget):
                                  tr("Set the game install path first."))
             return False
         try:
-            import crimson_rs
+            import crimson_rs, dmm_parser, copy
             dp = "gamedata/binary__/client/bin"
-            if self._allygroup_data is None:
-                ag_body = crimson_rs.extract_file(game_path, "0008", dp, "allygroupinfo.pabgb")
-                ag_schema = crimson_rs.extract_file(game_path, "0008", dp, "allygroupinfo.pabgh")
-                self._allygroup_data = bytearray(ag_body)
-                self._allygroup_original = bytes(ag_body)
-                self._allygroup_schema = bytes(ag_schema)
-            if self._relationinfo_data is None:
-                ri_body = crimson_rs.extract_file(game_path, "0008", dp, "relationinfo.pabgb")
-                ri_schema = crimson_rs.extract_file(game_path, "0008", dp, "relationinfo.pabgh")
-                self._relationinfo_data = bytearray(ri_body)
-                self._relationinfo_original = bytes(ri_body)
-                self._relationinfo_schema = bytes(ri_schema)
-            if self._factionrelgrp_data is None:
-                fg_body = crimson_rs.extract_file(game_path, "0008", dp, "factionrelationgroup.pabgb")
-                fg_schema = crimson_rs.extract_file(game_path, "0008", dp, "factionrelationgroup.pabgh")
-                self._factionrelgrp_data = bytearray(fg_body)
-                self._factionrelgrp_original = bytes(fg_body)
-                self._factionrelgrp_schema = bytes(fg_schema)
+
+            ag_gb = bytes(crimson_rs.extract_file(game_path, "0008", dp, "allygroupinfo.pabgb"))
+            ag_gh = bytes(crimson_rs.extract_file(game_path, "0008", dp, "allygroupinfo.pabgh"))
+            self._ally_dmm = dmm_parser.parse_table('ally_group_info', ag_gb, ag_gh)
+            self._ally_dmm_vanilla = copy.deepcopy(self._ally_dmm)
+            self._allygroup_data = bytearray(ag_gb)
+            self._allygroup_original = bytes(ag_gb)
+            self._allygroup_schema = bytes(ag_gh)
+
+            ri_gb = bytes(crimson_rs.extract_file(game_path, "0008", dp, "relationinfo.pabgb"))
+            ri_gh = bytes(crimson_rs.extract_file(game_path, "0008", dp, "relationinfo.pabgh"))
+            self._relation_dmm = dmm_parser.parse_table('relation_info', ri_gb, ri_gh)
+            self._relation_dmm_vanilla = copy.deepcopy(self._relation_dmm)
+            self._relationinfo_data = bytearray(ri_gb)
+            self._relationinfo_original = bytes(ri_gb)
+            self._relationinfo_schema = bytes(ri_gh)
+
+            fg_gb = bytes(crimson_rs.extract_file(game_path, "0008", dp, "factionrelationgroup.pabgb"))
+            fg_gh = bytes(crimson_rs.extract_file(game_path, "0008", dp, "factionrelationgroup.pabgh"))
+            self._factionrel_dmm = dmm_parser.parse_table('faction_relation_group_info', fg_gb, fg_gh)
+            self._factionrel_dmm_vanilla = copy.deepcopy(self._factionrel_dmm)
+            self._factionrelgrp_data = bytearray(fg_gb)
+            self._factionrelgrp_original = bytes(fg_gb)
+            self._factionrelgrp_schema = bytes(fg_gh)
+
+            log.info("Alliance loaded via dmm_parser: ally=%d relation=%d faction=%d",
+                     len(self._ally_dmm), len(self._relation_dmm), len(self._factionrel_dmm))
         except Exception as e:
             QMessageBox.critical(self, tr("Extract Failed"),
                                  f"Could not extract ally/relation/faction pabgbs:\n{e}")
@@ -2449,26 +2555,26 @@ class FieldEditTab(QWidget):
 
     def _parse_ally_index(self) -> list[tuple[int, int]]:
         s = self._allygroup_schema
-        count = struct.unpack_from("<H", s, 0)[0]
+        count = int.from_bytes(s[0:2], 'little')
         kw = (len(s) - 2 - count * 4) // count
         out = []
         p = 2
         for _ in range(count):
             key = int.from_bytes(s[p:p + kw], "little")
-            off = struct.unpack_from("<I", s, p + kw)[0]
+            off = int.from_bytes(s[p + kw:p + kw + 4], "little")
             out.append((key, off))
             p += kw + 4
         return out
 
     def _parse_relation_index(self) -> list[tuple[int, int]]:
         s = self._relationinfo_schema
-        count = struct.unpack_from("<H", s, 0)[0]
+        count = int.from_bytes(s[0:2], 'little')
         kw = (len(s) - 2 - count * 4) // count
         out = []
         p = 2
         for _ in range(count):
             key = int.from_bytes(s[p:p + kw], "little")
-            off = struct.unpack_from("<I", s, p + kw)[0]
+            off = int.from_bytes(s[p + kw:p + kw + 4], "little")
             out.append((key, off))
             p += kw + 4
         return out
@@ -2478,7 +2584,7 @@ class FieldEditTab(QWidget):
             return
         reply = QMessageBox.question(
             self, tr("Path A — All NPCs Hostile"),
-            "Set RelationInfo._order = 99 on all 45 entries?\n\n"
+            "Set RelationInfo.order = 99 on all entries?\n\n"
             "Everyone becomes max-hostile to everyone. Your mounts will\n"
             "damage guards. Side effect: town NPCs may attack each other.\n\n"
             "Fully reversible via Restore. Continue?",
@@ -2486,33 +2592,23 @@ class FieldEditTab(QWidget):
         if reply != QMessageBox.Yes:
             return
         flipped = 0
-        before: list[int] = []
-        after: list[int] = []
-        for _key, offset in self._parse_relation_index():
-            p = offset + 1
-            if p + 4 > len(self._relationinfo_data):
-                continue
-            slen = struct.unpack_from("<I", self._relationinfo_data, p)[0]
-            if slen > 200:
-                continue
-            order_pos = offset + 1 + 4 + slen + 1 + 1
-            if order_pos < len(self._relationinfo_data):
-                before.append(self._relationinfo_data[order_pos])
-                if self._relationinfo_data[order_pos] != 99:
-                    self._relationinfo_data[order_pos] = 99
-                    flipped += 1
-                after.append(self._relationinfo_data[order_pos])
-        log.info("path_a: flipped=%d/45, before=%s, after=%s",
-                 flipped, sorted(set(before)), sorted(set(after)))
+        for it in self._relation_dmm:
+            if it.get('order', 0) != 99:
+                it['order'] = 99
+                flipped += 1
+        import dmm_parser
+        self._relationinfo_data = bytearray(dmm_parser.serialize_table(
+            'relation_info', self._relation_dmm))
+        log.info("path_a (dmm_parser): set order=99 on %d entries", flipped)
         self._field_edit_status.setText(
-            tr(f"Path A: set _order=99 on {flipped} relation entries. Click Apply."))
+            f"Path A: set order=99 on {flipped} relation entries. Click Apply.")
 
     def _field_edit_wipe_ally_lists(self):
         if not self._ally_ensure_loaded():
             return
         reply = QMessageBox.question(
             self, tr("Path B — Wipe Ally Lists"),
-            "Zero out _addOnAllyGroupList (list #0) hashes on all 50 groups?\n\n"
+            "Clear add_on_ally_group_list on all ally groups?\n\n"
             "Effect: no faction is allied with any other. Guards still\n"
             "function (combat rules intact) but mutual defense is gone.\n\n"
             "Fully reversible via Restore. Continue?",
@@ -2520,67 +2616,56 @@ class FieldEditTab(QWidget):
         if reply != QMessageBox.Yes:
             return
         zeroed = 0
-        for _key, offset in self._parse_ally_index():
-            p = offset + 4
-            slen = struct.unpack_from("<I", self._allygroup_data, p)[0]
-            p += 4 + slen + 1
-            if p + 4 > len(self._allygroup_data):
-                continue
-            cnt = struct.unpack_from("<I", self._allygroup_data, p)[0]
-            if cnt > 200:
-                continue
-            hash_start = p + 4
-            hash_end = hash_start + cnt * 4
-            if hash_end <= len(self._allygroup_data):
-                for i in range(hash_start, hash_end):
-                    self._allygroup_data[i] = 0
-                zeroed += cnt
+        for it in self._ally_dmm:
+            lst = it.get('add_on_ally_group_list', [])
+            if lst:
+                zeroed += len(lst)
+                it['add_on_ally_group_list'] = []
+        import dmm_parser
+        self._allygroup_data = bytearray(dmm_parser.serialize_table(
+            'ally_group_info', self._ally_dmm))
+        log.info("path_b (dmm_parser): cleared %d ally hashes", zeroed)
         self._field_edit_status.setText(
-            tr(f"Path B: zeroed {zeroed} ally-group hashes across 50 entries. Click Apply."))
+            f"Path B: cleared {zeroed} ally-group hashes. Click Apply.")
 
     def _field_edit_set_ally_flag(self, slot: int):
         if slot < 0 or slot > 4:
             return
         if not self._ally_ensure_loaded():
             return
+        flag_names = {
+            0: 'is_intruder', 1: 'is_main_ally_group', 2: 'is_wild',
+            3: 'apply_reporting', 4: 'interesting_condition',
+        }
+        fname = flag_names.get(slot, f'flag_{slot}')
         reply = QMessageBox.question(
-            self, tr(f"Path C — Flag Slot {slot}"),
-            f"Set u8 flag #{slot} = 1 on all 50 AllyGroup entries?\n\n"
-            f"Experiment: one of the 5 flag slots is _isIntruder. Try this\n"
-            f"and tell me if NPCs attack each other.\n\n"
+            self, tr(f"Path C — {fname}"),
+            f"Set {fname} = 1 on all AllyGroup entries?\n\n"
             f"Fully reversible via Restore. Continue?",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
         if reply != QMessageBox.Yes:
             return
         set_count = 0
-        for _key, offset in self._parse_ally_index():
-            p = offset + 4
-            slen = struct.unpack_from("<I", self._allygroup_data, p)[0]
-            p += 4 + slen + 1
-            try:
-                for _ in range(7):
-                    cnt = struct.unpack_from("<I", self._allygroup_data, p)[0]
-                    if cnt > 200:
-                        raise ValueError("bad list count")
-                    p += 4 + cnt * 4
-                target = p + slot
-                if target < len(self._allygroup_data):
-                    self._allygroup_data[target] = 1
-                    set_count += 1
-            except Exception:
-                continue
+        for it in self._ally_dmm:
+            if it.get(fname, 0) != 1:
+                it[fname] = 1
+                set_count += 1
+        import dmm_parser
+        self._allygroup_data = bytearray(dmm_parser.serialize_table(
+            'ally_group_info', self._ally_dmm))
+        log.info("path_c (dmm_parser): set %s=1 on %d entries", fname, set_count)
         self._field_edit_status.setText(
-            tr(f"Path C: set flag #{slot}=1 on {set_count} ally groups. Click Apply."))
+            f"Path C: set {fname}=1 on {set_count} ally groups. Click Apply.")
 
     def _parse_factionrelgrp_index(self) -> list[tuple[int, int]]:
         s = self._factionrelgrp_schema
-        count = struct.unpack_from("<H", s, 0)[0]
+        count = int.from_bytes(s[0:2], 'little')
         kw = (len(s) - 2 - count * 4) // count
         out = []
         p = 2
         for _ in range(count):
             key = int.from_bytes(s[p:p + kw], "little")
-            off = struct.unpack_from("<I", s, p + kw)[0]
+            off = int.from_bytes(s[p + kw:p + kw + 4], "little")
             out.append((key, off))
             p += kw + 4
         return out
@@ -2588,56 +2673,34 @@ class FieldEditTab(QWidget):
     def _field_edit_wipe_faction_relation_allies(self, all_lists: bool = False):
         if not self._ally_ensure_loaded():
             return
-        label = "ALL 4 LISTS" if all_lists else "list #0 (allied)"
+        label = "ALL 4 LISTS" if all_lists else "rel_0 (allied)"
         reply = QMessageBox.question(
             self, tr(f"Path D — Wipe FactionRelationGroup {label}"),
-            f"Zero the hash bytes in {label} across all 5 FactionRelationGroup entries?\n\n"
-            f"Target: the 5 top-level groups (Civilian/Guard/Bandit/Player/...).\n"
+            f"Clear {label} across all FactionRelationGroup entries?\n\n"
+            f"Target: the top-level groups (Civilian/Guard/Bandit/Player/...).\n"
             f"This is the LEVEL ABOVE allygroupinfo — where guard immunity lives.\n\n"
             f"Fully reversible via Restore. Continue?",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
         if reply != QMessageBox.Yes:
             return
-        buf = self._factionrelgrp_data
         zeroed_entries = 0
         zeroed_hashes = 0
-        list_counts_seen: list[tuple[int, int, int, int]] = []
-        for key, offset in self._parse_factionrelgrp_index():
-            try:
-                p = offset + 2
-                slen = struct.unpack_from("<I", buf, p)[0]
-                p += 4 + slen
-                if slen > 200:
-                    log.warning("path_d: entry %d has bad slen=%d, skipping", key, slen)
-                    continue
-                p += 1
-                counts = []
-                for list_idx in range(4):
-                    if p + 4 > len(buf):
-                        raise ValueError(f"truncated at list {list_idx}")
-                    cnt = struct.unpack_from("<I", buf, p)[0]
-                    if cnt > 500:
-                        raise ValueError(f"bad cnt={cnt} at list {list_idx}")
-                    counts.append(cnt)
-                    hash_start = p + 4
-                    hash_end = hash_start + cnt * 2
-                    if hash_end > len(buf):
-                        raise ValueError(f"truncated hashes at list {list_idx}")
-                    if (all_lists or list_idx == 0) and cnt > 0:
-                        for i in range(hash_start, hash_end):
-                            buf[i] = 0
-                        zeroed_hashes += cnt
-                    p = hash_end
-                list_counts_seen.append(tuple(counts))
-                zeroed_entries += 1
-            except Exception as e:
-                log.exception("path_d: failed on entry key=%d offset=%d: %s",
-                              key, offset, e)
-        log.info("path_d: wiped %s on %d/5 entries; %d u16 hashes zeroed; per-entry counts=%s",
-                 label, zeroed_entries, zeroed_hashes, list_counts_seen)
+        list_fields = ['rel_0', 'rel_1', 'rel_2', 'rel_3'] if all_lists else ['rel_0']
+        for it in self._factionrel_dmm:
+            for lf in list_fields:
+                lst = it.get(lf, [])
+                if lst:
+                    zeroed_hashes += len(lst)
+                    it[lf] = []
+            zeroed_entries += 1
+        import dmm_parser
+        self._factionrelgrp_data = bytearray(dmm_parser.serialize_table(
+            'faction_relation_group_info', self._factionrel_dmm))
+        log.info("path_d (dmm_parser): wiped %s on %d entries, %d hashes cleared",
+                 label, zeroed_entries, zeroed_hashes)
         self._field_edit_status.setText(
-            tr(f"Path D: wiped {label} on {zeroed_entries} entries "
-               f"({zeroed_hashes} hashes zeroed). Click Apply."))
+            f"Path D: wiped {label} on {zeroed_entries} entries "
+               f"({zeroed_hashes} hashes zeroed). Click Apply.")
 
     def _field_edit_invincible_mounts(self):
         if not self._charinfo_data or not self._charinfo_schema:
@@ -2679,7 +2742,15 @@ class FieldEditTab(QWidget):
             QMessageBox.information(self, tr("FieldEdit"), tr("Load FieldInfo first."))
             return
         v_count = 0
-        if self._vehicle_data and self._vehicle_entries:
+        vi_dmm = getattr(self, '_vehicleinfo_dmm_items', None)
+        if vi_dmm:
+            for vit in vi_dmm:
+                if vit.get('send_damage_to', 1) == 0:
+                    vit['send_damage_to'] = 1
+                    v_count += 1
+            self._vehicleinfo_dmm_dirty = True
+            self._vehicle_populate()
+        elif self._vehicle_data and self._vehicle_entries:
             for e in self._vehicle_entries:
                 off = e.get('can_call_safe_zone_offset', -1)
                 if off >= 0 and e.get('can_call_safe_zone', 0) == 0:
@@ -2688,60 +2759,62 @@ class FieldEditTab(QWidget):
                     v_count += 1
             self._vehicle_populate()
         ri_count = 0
-        if self._regioninfo_data and self._regioninfo_entries:
-            from regioninfo_parser import parse_pabgh_index as ri_idx_fn
-            ri_idx = ri_idx_fn(self._regioninfo_schema)
-            for e in self._regioninfo_entries:
-                if e.get('_limitVehicleRun', 0) or e.get('_isTown', 0):
-                    entry_off = ri_idx.get(e['_key'])
-                    if entry_off is not None:
-                        p = entry_off
-                        p += 2
-                        slen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + slen
-                        p += 1
-                        p += 1; p += 8
-                        dslen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + dslen
-                        p += 4
-                        rk_c = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + rk_c * 8
-                        p += 2
-                        cr_c = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + cr_c * 2
-                        p += 2; p += 4; p += 1; p += 4
-                        if e.get('_limitVehicleRun', 0):
-                            self._regioninfo_data[p] = 0
-                            e['_limitVehicleRun'] = 0
-                            ri_count += 1
-                        if e.get('_isTown', 0):
-                            self._regioninfo_data[p + 1] = 0
-                            e['_isTown'] = 0
-                            ri_count += 1
-            # Switch to 'All regions' so table stays populated after clearing flags
+        ri_dmm = getattr(self, '_regioninfo_dmm_items', None)
+        if ri_dmm:
+            for rit in ri_dmm:
+                if rit.get('limit_vehicle_run', 0):
+                    rit['limit_vehicle_run'] = 0
+                    ri_count += 1
+                if rit.get('is_town', 0):
+                    rit['is_town'] = 0
+                    ri_count += 1
+            if ri_count:
+                self._regioninfo_dmm_dirty = True
             if self._ri_filter_combo.currentData() != 'all':
                 self._ri_filter_combo.blockSignals(True)
-                self._ri_filter_combo.setCurrentIndex(1)  # 'All regions'
+                self._ri_filter_combo.setCurrentIndex(1)
+                self._ri_filter_combo.blockSignals(False)
+            self._regioninfo_populate()
+        elif self._regioninfo_entries:
+            for e in self._regioninfo_entries:
+                dmm_r = e.get('_dmm_ref')
+                if e.get('_limitVehicleRun', 0):
+                    if dmm_r:
+                        dmm_r['limit_vehicle_run'] = 0
+                    e['_limitVehicleRun'] = 0
+                    ri_count += 1
+                if e.get('_isTown', 0):
+                    if dmm_r:
+                        dmm_r['is_town'] = 0
+                    e['_isTown'] = 0
+                    ri_count += 1
+            if self._ri_filter_combo.currentData() != 'all':
+                self._ri_filter_combo.blockSignals(True)
+                self._ri_filter_combo.setCurrentIndex(1)
                 self._ri_filter_combo.blockSignals(False)
             self._regioninfo_populate()
         mount_count = 0
         patched_names: list[str] = []
         candidates = 0
-        if self._charinfo_data and self._charinfo_mount_entries:
-            for e in self._charinfo_mount_entries:
-                dur = e.get('_callMercenarySpawnDuration', 0)
-                cool = e.get('_callMercenaryCoolTime', 0)
+        dmm_items = getattr(self, '_charinfo_dmm_items', None)
+        if dmm_items:
+            for it in dmm_items:
+                if it.get('vehicle_info', 0) == 0:
+                    continue
+                dur = it.get('call_mercenary_spawn_duration', 0)
+                cool = it.get('call_mercenary_cool_time', 0)
                 if dur > 0 or cool > 0:
                     candidates += 1
                 hit = False
                 if dur > 0:
-                    off = e['_callMercenarySpawnDuration_offset']
-                    struct.pack_into('<Q', self._charinfo_data, off, 0x7FFFFFFF)
-                    e['_callMercenarySpawnDuration'] = 0x7FFFFFFF
+                    it['call_mercenary_spawn_duration'] = 0x7FFFFFFF
                     mount_count += 1; hit = True
                 if cool > 0:
-                    off = e['_callMercenaryCoolTime_offset']
-                    struct.pack_into('<Q', self._charinfo_data, off, 0)
-                    e['_callMercenaryCoolTime'] = 0
+                    it['call_mercenary_cool_time'] = 0
                     mount_count += 1; hit = True
                 if hit:
-                    patched_names.append(e.get('name', '?'))
+                    patched_names.append(it.get('string_key', '?'))
+            self._charinfo_dmm_dirty = True
             self._mount_populate()
         self._field_edit_modified = True
         log.info("enable_mounts: vehicle=%d region=%d mount=%d edits applied "
@@ -3690,6 +3763,13 @@ class FieldEditTab(QWidget):
 
             new_data, applied, report = apply_mesh_swaps(
                 pre_bytes, bytes(pabgh), list(queue))
+            # Mesh swap now uses dmm_parser — re-parse so dmm items stay in sync
+            if applied:
+                import dmm_parser as _dmp
+                import copy as _copy
+                self._charinfo_dmm_items = _dmp.parse_table(
+                    'character_info', bytes(new_data), bytes(pabgh))
+                self._charinfo_dmm_dirty = True
 
             mesh_diff = sum(1 for a, b in zip(new_data, pre_bytes) if a != b)
             log.info("mesh swap: queue=%d applied=%d diff_bytes=%d",
@@ -4029,48 +4109,112 @@ class FieldEditTab(QWidget):
                      len(dirty_names), ", ".join(dirty_names))
 
         try:
-            import crimson_rs.pack_mod
+            import crimson_rs
+            INTERNAL_DIR = "gamedata/binary__/client/bin"
             gp = Path(game_path)
-            mod_group = f"{self._fieldedit_overlay_spin.value():04d}"
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                mod_dir = os.path.join(tmp_dir, "gamedata", "binary__", "client", "bin")
-                os.makedirs(mod_dir, exist_ok=True)
-                self._write_modified_files(mod_dir)
+            base_group = self._fieldedit_overlay_spin.value()
 
-                pack_out = os.path.join(tmp_dir, "output")
-                os.makedirs(pack_out, exist_ok=True)
-                crimson_rs.pack_mod.pack_mod(
-                    game_dir=game_path,
-                    mod_folder=tmp_dir,
-                    output_dir=pack_out,
-                    group_name=mod_group,
-                )
-                try:
-                    pamt_path = os.path.join(pack_out, mod_group, "0.pamt")
-                    if os.path.isfile(pamt_path):
-                        import re as _re
-                        with open(pamt_path, "rb") as _f:
-                            _pamt = _f.read()
-                        _files = sorted(set(
-                            m.decode('ascii', errors='replace')
-                            for m in _re.findall(rb'[A-Za-z0-9_]+\.pabgb', _pamt)))
-                        log.info("field_edit pack_mod verifier: PAMT lists %d file(s): %s",
-                                 len(_files), ", ".join(_files) if _files else "(none)")
-                except Exception:
-                    log.exception("field_edit pack_mod post-verify failed")
-                papgt_path = gp / "meta" / "0.papgt"
-                backup_path = papgt_path.with_suffix(".papgt.field_bak")
-                if papgt_path.exists() and not backup_path.exists():
-                    shutil.copy2(papgt_path, backup_path)
-                dest = gp / mod_group
-                dest.mkdir(exist_ok=True)
-                shutil.copyfile(os.path.join(pack_out, mod_group, "0.paz"), dest / "0.paz")
-                shutil.copyfile(os.path.join(pack_out, mod_group, "0.pamt"), dest / "0.pamt")
-                shutil.copyfile(os.path.join(pack_out, "meta", "0.papgt"), papgt_path)
+            dirty_tables = []
+            table_defs = [
+                ("fieldinfo",     self._field_edit_data,    self._field_edit_original),
+                ("gameplaytrigger", self._gptrigger_data,   self._gptrigger_original),
+                ("wantedinfo",    self._wantedinfo_data,    self._wantedinfo_original),
+                ("allygroupinfo", self._allygroup_data,     self._allygroup_original),
+                ("relationinfo",  self._relationinfo_data,  self._relationinfo_original),
+                ("factionrelationgroup", self._factionrelgrp_data, self._factionrelgrp_original),
+            ]
+            for stem, data, orig in table_defs:
+                if data is not None and orig is not None and bytes(data) != orig:
+                    dirty_tables.append((stem, bytes(data)))
 
-            self._field_edit_status.setText(f"Applied to {mod_group}/")
+            # vehicleinfo: prefer dmm_parser field-level serialization
+            _vi_dmm_dirty = getattr(self, '_vehicleinfo_dmm_dirty', False)
+            _vi_dmm_items = getattr(self, '_vehicleinfo_dmm_items', None)
+            _vi_byte_dirty = (self._vehicle_data is not None
+                              and self._vehicle_original is not None
+                              and bytes(self._vehicle_data) != self._vehicle_original)
+            if _vi_dmm_dirty and _vi_dmm_items:
+                import dmm_parser as _dmp
+                vi_pabgb = bytes(_dmp.serialize_table('vehicle_info', _vi_dmm_items))
+                dirty_tables.append(("vehicleinfo", vi_pabgb))
+                log.info("vehicleinfo: serialized via dmm_parser (%d bytes)", len(vi_pabgb))
+            elif _vi_byte_dirty:
+                dirty_tables.append(("vehicleinfo", bytes(self._vehicle_data)))
+                log.info("vehicleinfo: using byte-patched data")
+
+            # regioninfo: prefer dmm_parser field-level serialization
+            _ri_dmm_dirty = getattr(self, '_regioninfo_dmm_dirty', False)
+            _ri_dmm_items = getattr(self, '_regioninfo_dmm_items', None)
+            _ri_byte_dirty = (self._regioninfo_data is not None
+                              and self._regioninfo_original is not None
+                              and bytes(self._regioninfo_data) != self._regioninfo_original)
+            if _ri_dmm_dirty and _ri_dmm_items:
+                import dmm_parser as _dmp
+                ri_pabgb = bytes(_dmp.serialize_table('region_info', _ri_dmm_items))
+                dirty_tables.append(("regioninfo", ri_pabgb))
+                log.info("regioninfo: serialized via dmm_parser (%d bytes)", len(ri_pabgb))
+            elif _ri_byte_dirty:
+                dirty_tables.append(("regioninfo", bytes(self._regioninfo_data)))
+                log.info("regioninfo: using byte-patched data")
+
+            # characterinfo: prefer dmm_parser field-level serialization
+            _dmm_dirty = getattr(self, '_charinfo_dmm_dirty', False)
+            _dmm_items = getattr(self, '_charinfo_dmm_items', None)
+            _byte_dirty = (self._charinfo_data is not None
+                           and self._charinfo_original is not None
+                           and bytes(self._charinfo_data) != self._charinfo_original)
+            if _dmm_dirty and _dmm_items:
+                import dmm_parser as _dmp
+                ci_pabgb = bytes(_dmp.serialize_table('character_info', _dmm_items))
+                dirty_tables.append(("characterinfo", ci_pabgb))
+                log.info("characterinfo: serialized via dmm_parser (%d bytes)", len(ci_pabgb))
+            elif _byte_dirty:
+                dirty_tables.append(("characterinfo", bytes(self._charinfo_data)))
+                log.info("characterinfo: using byte-patched data (%d bytes)", len(self._charinfo_data))
+
+            if not dirty_tables:
+                log.warning("FieldEdit apply: no dirty tables")
+
+            papgt_path = gp / "meta" / "0.papgt"
+            backup_path = papgt_path.with_suffix(".papgt.field_bak")
+            if papgt_path.exists() and not backup_path.exists():
+                shutil.copy2(papgt_path, backup_path)
+
+            deployed = []
+            for i, (stem, pabgb_data) in enumerate(dirty_tables):
+                grp = f"{base_group + i:04d}"
+                pabgh_data = bytes(crimson_rs.extract_file(
+                    game_path, "0008", INTERNAL_DIR, f"{stem}.pabgh"))
+
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    group_dir = os.path.join(tmp_dir, grp)
+                    builder = crimson_rs.PackGroupBuilder(
+                        group_dir, crimson_rs.Compression.NONE,
+                        crimson_rs.Crypto.NONE)
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgb", pabgb_data)
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgh", pabgh_data)
+                    pamt_bytes = bytes(builder.finish())
+                    pamt_checksum = crimson_rs.parse_pamt_bytes(pamt_bytes)["checksum"]
+
+                    dest = gp / grp
+                    dest.mkdir(exist_ok=True)
+                    for fn in os.listdir(group_dir):
+                        shutil.copy2(os.path.join(group_dir, fn), str(dest / fn))
+
+                papgt = crimson_rs.parse_papgt_file(str(papgt_path))
+                papgt["entries"] = [e for e in papgt["entries"]
+                                    if e.get("group_name") != grp]
+                papgt = crimson_rs.add_papgt_entry(
+                    papgt, grp, pamt_checksum, 0, 16383)
+                crimson_rs.write_papgt_file(papgt, str(papgt_path))
+                deployed.append(f"{stem} -> {grp}/")
+                log.info("FieldEdit deployed %s to %s/ (%d bytes)",
+                         stem, grp, len(pabgb_data))
+
+            summary = "\n".join(f"  {d}" for d in deployed)
+            self._field_edit_status.setText(f"Applied {len(deployed)} table(s)")
             QMessageBox.information(self, tr("Applied"),
-                f"FieldInfo mod deployed to {mod_group}/.\n"
+                f"FieldInfo mod deployed:\n{summary}\n\n"
                 f"Restart the game for changes to take effect.")
         except Exception as e:
             log.exception("FieldEdit apply failed")
@@ -4288,35 +4432,16 @@ class FieldEditTab(QWidget):
             if ch:
                 patches.append({"game_file": "gamedata/gameplaytrigger.pabgb", "changes": ch})
 
-        if self._regioninfo_data and self._regioninfo_original:
-            ri_field_map = {}
-            if self._regioninfo_entries:
-                from regioninfo_parser import parse_pabgh_index as ri_idx_fn
-                ri_idx = ri_idx_fn(self._regioninfo_schema)
-                for e in self._regioninfo_entries:
-                    entry_off = ri_idx.get(e['_key'])
-                    if entry_off is None:
-                        continue
-                    rname = e.get('_stringKey', f"Region_{e['_key']}")
-                    p = entry_off
-                    p += 2
-                    slen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + slen
-                    p += 1
-                    p += 1; p += 8
-                    dslen = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + dslen
-                    p += 4
-                    rk_c = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + rk_c * 8
-                    p += 2
-                    cr_c = struct.unpack_from('<I', self._regioninfo_data, p)[0]; p += 4 + cr_c * 2
-                    p += 2; p += 4; p += 1; p += 4
-                    ri_field_map[p] = f"{rname}: _limitVehicleRun"
-                    ri_field_map[p + 1] = f"{rname}: _isTown"
-                    ri_field_map[p + 2] = f"{rname}: _isWild"
-            def _ri_label(off, _n):
-                return ri_field_map.get(off, f"regioninfo offset {off}")
-            ch = _diff_bytes(self._regioninfo_data, self._regioninfo_original, _ri_label)
-            if ch:
-                patches.append({"game_file": "gamedata/regioninfo.pabgb", "changes": ch})
+        if self._regioninfo_entries and hasattr(self, '_regioninfo_dmm_items') and self._regioninfo_dmm_items:
+            import dmm_parser as _dmp_ri_exp
+            cur_ri = _dmp_ri_exp.serialize_table('region_info', self._regioninfo_dmm_items)
+            van_ri = _dmp_ri_exp.serialize_table('region_info', self._regioninfo_dmm_vanilla)
+            if cur_ri != van_ri:
+                def _ri_label(off, _n):
+                    return f"regioninfo offset {off}"
+                ch = _diff_bytes(cur_ri, van_ri, _ri_label)
+                if ch:
+                    patches.append({"game_file": "gamedata/regioninfo.pabgb", "changes": ch})
 
         if self._charinfo_data and self._charinfo_original:
             ci_field_map = {}

--- a/CrimsonGameMods/gui/tabs/world.py
+++ b/CrimsonGameMods/gui/tabs/world.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import shutil
-import struct
 import sys
 from typing import Callable, List, Optional
 
@@ -432,27 +431,30 @@ class GameDataTab(QWidget):
         label = "100% (max)" if multiplier == 0 else f"{multiplier}x"
         reply = QMessageBox.question(
             self, tr("Batch Drop Rate Edit"),
-            f"Set ALL drop rates to {label} across {len(pf.records)} drop sets?\n\n"
-            f"This modifies rate-like u32 values (100-100000 range, ×100 basis).\n",
+            f"Set ALL drop rates to {label} across all drop sets?\n\n"
+            f"Modifies rate fields via dmm_parser (update-proof).\n",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
         )
         if reply != QMessageBox.Yes:
             return
 
-        from pabgb_field_parsers import _scan_rates
+        import dmm_parser as _dmp_dr
+        drops = _dmp_dr.parse_table('drop_set_info', bytes(pf.body_bytes),
+                                     pf.header_bytes)
         changed = 0
-        for rec in pf.records:
-            rates = _scan_rates(pf.body_bytes, rec.offset, rec.offset + rec.size)
-            for rate_field in rates:
-                old_val = rate_field.value
-                if multiplier == 0:
-                    new_val = 10000
-                else:
-                    new_val = min(old_val * multiplier, 10000)
-                if new_val != old_val:
-                    struct.pack_into('<I', pf.body_bytes, rate_field.offset, new_val)
-                    changed += 1
+        for d in drops:
+            for item in d.get('list', []):
+                old_val = item.get('raw_16', 0)
+                if 100 <= old_val <= 100000 and old_val % 100 == 0:
+                    if multiplier == 0:
+                        new_val = 10000
+                    else:
+                        new_val = min(old_val * multiplier, 10000)
+                    if new_val != old_val:
+                        item['raw_16'] = new_val
+                        changed += 1
 
+        pf.body_bytes = bytearray(_dmp_dr.serialize_table('drop_set_info', drops))
         self._gd_status.setText(f"Modified {changed} rate values to {label}")
         self._gd_record_selected()
 
@@ -467,22 +469,24 @@ class GameDataTab(QWidget):
 
         reply = QMessageBox.question(
             self, tr("Zero Cooldowns"),
-            f"Set all cooldown timers to 100ms across {len(pf.records)} skills?\n\n"
-            f"This modifies u32 values in the 500-120000 range (millisecond timers).\n",
+            f"Set all cooldown timers to 100ms?\n\n"
+            f"Modifies cooltime field via dmm_parser (update-proof).\n",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
         )
         if reply != QMessageBox.Yes:
             return
 
+        import dmm_parser as _dmp_sk
+        skills = _dmp_sk.parse_table('skill_info', bytes(pf.body_bytes),
+                                      pf.header_bytes)
         changed = 0
-        for rec in pf.records:
-            end = rec.offset + rec.size
-            for off in range(rec.offset, min(end - 3, len(pf.body_bytes) - 3), 4):
-                v = struct.unpack_from('<I', pf.body_bytes, off)[0]
-                if 500 <= v <= 120000 and v % 100 == 0:
-                    struct.pack_into('<I', pf.body_bytes, off, 100)
-                    changed += 1
+        for sk in skills:
+            ct = sk.get('cooltime', 0)
+            if ct > 100:
+                sk['cooltime'] = 100
+                changed += 1
 
+        pf.body_bytes = bytearray(_dmp_sk.serialize_table('skill_info', skills))
         self._gd_status.setText(f"Zeroed {changed} cooldown values")
         self._gd_record_selected()
 
@@ -688,12 +692,27 @@ class StoreEditorTab(QWidget):
         splitter.setSizes([300, 500])
         layout.addWidget(splitter, 1)
 
-        self._store_parser = None
+        self._store_dmm = None
         self._store_modified = False
         self._store_change_count = 0
-        self._store_original_body = None
-        self._store_original_header = None
 
+
+    def _store_get_item_name(self, item_key: int) -> str:
+        if not hasattr(self, '_store_item_names'):
+            self._store_item_names = {}
+            try:
+                db = get_connection()
+                for row in db.execute("SELECT item_key, name FROM items"):
+                    self._store_item_names[row['item_key']] = row['name']
+            except Exception:
+                pass
+        return self._store_item_names.get(item_key, f"Item_{item_key}")
+
+    def _store_get_stock_item_key(self, stock: dict) -> int:
+        v = stock.get('value')
+        if isinstance(v, dict):
+            return v.get('raw_q', 0)
+        return 0
 
     def _store_extract(self) -> None:
         game_path = self._game_path.strip()
@@ -705,21 +724,19 @@ class StoreEditorTab(QWidget):
         QApplication.processEvents()
 
         try:
-            from store_editor import StoreInfoParser as _OldParser
-            old_parser = _OldParser(game_path)
-            ok = old_parser.extract()
-            if not ok:
-                self._store_status.setText(tr("Failed to extract storeinfo from PAZ"))
-                return
+            import crimson_rs, dmm_parser, copy
+            dp = "gamedata/binary__/client/bin"
+            gb = bytes(crimson_rs.extract_file(game_path, "0008", dp, "storeinfo.pabgb"))
+            gh = bytes(crimson_rs.extract_file(game_path, "0008", dp, "storeinfo.pabgh"))
+            self._store_dmm = dmm_parser.parse_table('store_info', gb, gh)
+            self._store_dmm_vanilla = copy.deepcopy(self._store_dmm)
+            self._store_gh = gh
+            self._store_game_path = game_path
 
-            from storeinfo_parser import StoreinfoParser
-            self._store_parser_v2 = StoreinfoParser()
-            self._store_parser_v2.load_from_bytes(old_parser._header_data, bytes(old_parser._body_data))
-            self._store_parser_v2.load_names()
-            self._store_parser = old_parser
-            self._store_original_body = bytes(old_parser._body_data)
-            self._store_original_header = bytes(old_parser._header_data)
-            self._store_status.setText(self._store_parser_v2.get_summary())
+            log.info("Store loaded via dmm_parser: %d stores", len(self._store_dmm))
+            self._store_status.setText(
+                f"Loaded {len(self._store_dmm)} stores, "
+                f"{sum(len(s.get('stock_data_list', [])) for s in self._store_dmm)} stock items")
             self._store_populate_list()
             self._store_modified = False
             self._store_change_count = 0
@@ -738,7 +755,7 @@ class StoreEditorTab(QWidget):
             self._store_changes_label.setText("")
 
     def _store_populate_list(self, filter_text: str = "") -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             return
 
         if not hasattr(self, '_store_display_names'):
@@ -753,39 +770,40 @@ class StoreEditorTab(QWidget):
                 pass
 
         q = filter_text.lower().strip()
-        stores = self._store_parser_v2.stores
+        stores = self._store_dmm
         if q:
             stores = [s for s in stores
-                      if q in s.name.lower()
-                      or q in str(s.key)
-                      or q in self._store_display_names.get(str(s.key), "").lower()]
+                      if q in s.get('string_key', '').lower()
+                      or q in str(s.get('key', ''))
+                      or q in self._store_display_names.get(str(s.get('key', '')), "").lower()]
 
         table = self._store_list
         table.setSortingEnabled(False)
         table.setRowCount(len(stores))
         for row, store in enumerate(stores):
+            skey = store.get('key', 0)
+            sname = store.get('string_key', '')
+            stock = store.get('stock_data_list', [])
+
             key_item = QTableWidgetItem()
-            key_item.setData(Qt.DisplayRole, store.key)
-            key_item.setData(Qt.UserRole, store.key)
+            key_item.setData(Qt.DisplayRole, skey)
+            key_item.setData(Qt.UserRole, skey)
             table.setItem(row, 0, key_item)
 
-            display = self._store_display_names.get(str(store.key), "")
+            display = self._store_display_names.get(str(skey), "")
             if not display:
-                display = store.name.replace("Store_", "").replace("_", " ")
+                display = sname.replace("Store_", "").replace("_", " ")
             name_item = QTableWidgetItem(display)
-            name_item.setToolTip(store.name)
+            name_item.setToolTip(sname)
             table.setItem(row, 1, name_item)
 
             count_item = QTableWidgetItem()
-            count_item.setData(Qt.DisplayRole, len(store.items))
-            if store.items:
+            count_item.setData(Qt.DisplayRole, len(stock))
+            if stock:
                 count_item.setForeground(QBrush(QColor(COLORS['success'])))
             table.setItem(row, 2, count_item)
 
-            fmt = "Standard" if store.is_standard else "Special"
-            fmt_item = QTableWidgetItem(fmt)
-            if not store.is_standard:
-                fmt_item.setForeground(QBrush(QColor(COLORS['text_dim'])))
+            fmt_item = QTableWidgetItem("Parsed")
             table.setItem(row, 3, fmt_item)
         table.setSortingEnabled(True)
 
@@ -793,7 +811,7 @@ class StoreEditorTab(QWidget):
         self._store_populate_list(text)
 
     def _store_get_selected_store(self):
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             return None
         rows = self._store_list.selectionModel().selectedRows()
         if not rows:
@@ -801,38 +819,48 @@ class StoreEditorTab(QWidget):
         key_item = self._store_list.item(rows[0].row(), 0)
         if not key_item:
             return None
-        return self._store_parser_v2.get_store_by_key(key_item.data(Qt.UserRole))
+        target_key = key_item.data(Qt.UserRole)
+        for s in self._store_dmm:
+            if s.get('key') == target_key:
+                return s
+        return None
 
     def _store_selected(self, *_args) -> None:
         store = self._store_get_selected_store()
         if not store:
             return
 
+        stock_list = store.get('stock_data_list', [])
         table = self._store_items_table
         self._store_suppress_cell_edit = True
         table.setSortingEnabled(False)
-        table.setRowCount(len(store.items))
+        table.setRowCount(len(stock_list))
 
         non_editable_flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
         editable_flags = non_editable_flags | Qt.ItemIsEditable
 
-        for row, item in enumerate(store.items):
+        for row, stock in enumerate(stock_list):
+            item_key = self._store_get_stock_item_key(stock)
+            buy_price = stock.get('raw_a', 0)
+            sell_price = stock.get('raw_b', 0)
+            trade_flags = stock.get('raw_c', 0)
+
             icon_item = QTableWidgetItem()
             if self._icons_enabled:
-                px = self._icon_cache.get_pixmap(item.item_key)
+                px = self._icon_cache.get_pixmap(item_key)
                 if px:
                     icon_item.setIcon(QIcon(px))
             icon_item.setFlags(non_editable_flags)
             table.setItem(row, 0, icon_item)
 
             key_cell = QTableWidgetItem()
-            key_cell.setData(Qt.DisplayRole, item.item_key)
+            key_cell.setData(Qt.DisplayRole, item_key)
             key_cell.setData(Qt.UserRole, row)
             key_cell.setFlags(non_editable_flags)
             table.setItem(row, 1, key_cell)
 
-            name = self._store_parser_v2.get_item_name(item.item_key)
-            cat = self._name_db.get_category(item.item_key) if hasattr(self, '_name_db') else ""
+            name = self._store_get_item_name(item_key)
+            cat = self._name_db.get_category(item_key) if hasattr(self, '_name_db') else ""
             color = QColor(CATEGORY_COLORS.get(cat, COLORS["text"]))
             name_w = QTableWidgetItem(name)
             name_w.setForeground(QBrush(color))
@@ -845,21 +873,21 @@ class StoreEditorTab(QWidget):
             table.setItem(row, 3, cat_w)
 
             limit_w = QTableWidgetItem()
-            limit_w.setData(Qt.DisplayRole, item.trade_flags)
-            if item.trade_flags >= 999:
+            limit_w.setData(Qt.DisplayRole, trade_flags)
+            if trade_flags >= 999:
                 limit_w.setForeground(QBrush(QColor(COLORS['success'])))
             limit_w.setFlags(editable_flags)
             limit_w.setToolTip("Double-click to edit purchase limit")
             table.setItem(row, 4, limit_w)
 
             buy_w = QTableWidgetItem()
-            buy_w.setData(Qt.DisplayRole, item.buy_price)
+            buy_w.setData(Qt.DisplayRole, buy_price)
             buy_w.setFlags(editable_flags)
             buy_w.setToolTip("Double-click to edit buy price")
             table.setItem(row, 5, buy_w)
 
             sell_w = QTableWidgetItem()
-            sell_w.setData(Qt.DisplayRole, item.sell_price)
+            sell_w.setData(Qt.DisplayRole, sell_price)
             sell_w.setFlags(editable_flags)
             sell_w.setToolTip("Double-click to edit sell price")
             table.setItem(row, 6, sell_w)
@@ -873,17 +901,18 @@ class StoreEditorTab(QWidget):
         col = cell.column()
         if col not in (4, 5, 6):
             return
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             return
 
         store = self._store_get_selected_store()
-        if not store or not store.is_standard:
+        if not store:
             return
 
+        stock_list = store.get('stock_data_list', [])
         row = cell.row()
-        if row >= len(store.items):
+        if row >= len(stock_list):
             return
-        item = store.items[row]
+        stock = stock_list[row]
 
         raw = cell.data(Qt.DisplayRole)
         try:
@@ -892,17 +921,15 @@ class StoreEditorTab(QWidget):
                 raise ValueError
         except (TypeError, ValueError):
             self._store_suppress_cell_edit = True
-            orig = {4: item.trade_flags, 5: item.buy_price, 6: item.sell_price}[col]
+            orig = {4: stock.get('raw_c', 0), 5: stock.get('raw_a', 0), 6: stock.get('raw_b', 0)}[col]
             cell.setData(Qt.DisplayRole, orig)
             self._store_suppress_cell_edit = False
             return
 
-        body = self._store_parser_v2._body_data
         if col == 4:
             if new_val > 0xFFFFFFFF:
                 new_val = 0xFFFFFFFF
-            struct.pack_into('<I', body, item.offset + 0x12, new_val)
-            item.trade_flags = new_val
+            stock['raw_c'] = new_val
             if new_val >= 999:
                 cell.setForeground(QBrush(QColor(COLORS['success'])))
             else:
@@ -910,19 +937,17 @@ class StoreEditorTab(QWidget):
         elif col == 5:
             if new_val > 0xFFFFFFFFFFFFFFFF:
                 new_val = 0xFFFFFFFFFFFFFFFF
-            struct.pack_into('<Q', body, item.offset + 0x02, new_val)
-            item.buy_price = new_val
+            stock['raw_a'] = new_val
         elif col == 6:
             if new_val > 0xFFFFFFFFFFFFFFFF:
                 new_val = 0xFFFFFFFFFFFFFFFF
-            struct.pack_into('<Q', body, item.offset + 0x0A, new_val)
-            item.sell_price = new_val
+            stock['raw_b'] = new_val
 
-        self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
         self._store_update_change_count(1)
+        item_key = self._store_get_stock_item_key(stock)
         col_name = {4: 'limit', 5: 'buy price', 6: 'sell price'}[col]
         self._store_status.setText(
-            f"Set {col_name}={new_val} on {self._store_parser_v2.get_item_name(item.item_key)}"
+            f"Set {col_name}={new_val} on {self._store_get_item_name(item_key)}"
         )
 
     def _store_get_selected_items(self):
@@ -930,19 +955,21 @@ class StoreEditorTab(QWidget):
         return sorted(rows)
 
     def _store_swap_item(self) -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             QMessageBox.warning(self, tr("Stores"), tr("Load store data first."))
             return
 
         store = self._store_get_selected_store()
-        if not store or not store.is_standard:
-            QMessageBox.warning(self, tr("Swap"), tr("Select a standard-format store first."))
+        if not store:
+            QMessageBox.warning(self, tr("Swap"), tr("Select a store first."))
             return
 
         sel_rows = self._store_get_selected_items()
         if not sel_rows:
             QMessageBox.information(self, tr("No Selection"), tr("Select item(s) to swap."))
             return
+
+        stock_list = store.get('stock_data_list', [])
 
         dlg = ItemSearchDialog(
             self._name_db,
@@ -961,7 +988,7 @@ class StoreEditorTab(QWidget):
             except ValueError:
                 q = text.strip().lower()
                 new_key = 0
-                for k, n in self._store_parser_v2._name_lookup.items():
+                for k, n in getattr(self, '_store_item_names', {}).items():
                     if q in n.lower():
                         new_key = k
                         break
@@ -973,46 +1000,52 @@ class StoreEditorTab(QWidget):
                 return
             new_key = dlg.selected_key
 
-        new_name = self._store_parser_v2.get_item_name(new_key)
+        new_name = self._store_get_item_name(new_key)
 
         swapped = 0
         for row in sel_rows:
-            if row < len(store.items):
-                item = store.items[row]
-                ok = self._store_parser_v2.swap_item(store.key, item.item_key, new_key)
-                if ok:
+            if row < len(stock_list):
+                stock = stock_list[row]
+                v = stock.get('value')
+                if isinstance(v, dict):
+                    v['raw_q'] = new_key
+                    p = v.get('payload')
+                    if isinstance(p, dict):
+                        p['body'] = new_key
                     swapped += 1
                     self._store_update_change_count()
 
         if swapped:
-            self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
             self._store_status.setText(f"Swapped {swapped} item(s) to {new_name}")
             self._store_selected()
         else:
             QMessageBox.warning(self, tr("Swap Failed"), tr("Could not swap any items."))
 
     def _store_add_item(self) -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             QMessageBox.warning(self, tr("Stores"), tr("Load store data first."))
             return
 
         store = self._store_get_selected_store()
-        if not store or not store.is_standard:
-            QMessageBox.warning(self, tr("Add"), tr("Select a standard-format store."))
+        if not store:
+            QMessageBox.warning(self, tr("Add"), tr("Select a store."))
             return
 
+        stock_list = store.get('stock_data_list', [])
         sel_rows = self._store_get_selected_items()
-        if not sel_rows:
+        if not sel_rows or sel_rows[0] >= len(stock_list):
             QMessageBox.information(self, tr("No Selection"),
                 tr("Select an existing item to use as template (donor)."))
             return
 
-        donor = store.items[sel_rows[0]]
+        import copy as _copy
+        donor = stock_list[sel_rows[0]]
+        donor_key = self._store_get_stock_item_key(donor)
 
         dlg = ItemSearchDialog(
             self._name_db,
             title="Add Item to Store",
-            prompt=f"Select the item to add (cloned from {self._store_parser_v2.get_item_name(donor.item_key)}):",
+            prompt=f"Select the item to add (cloned from {self._store_get_item_name(donor_key)}):",
             parent=self,
         ) if hasattr(self, '_name_db') else None
 
@@ -1022,73 +1055,71 @@ class StoreEditorTab(QWidget):
             return
 
         new_key = dlg.selected_key
-        new_name = self._store_parser_v2.get_item_name(new_key)
+        new_name = self._store_get_item_name(new_key)
 
-        ok = self._store_parser_v2.add_item(store.key, donor.item_key, new_key)
-        if ok:
-            self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
-            self._store_parser._header_data = self._store_parser_v2.get_header_bytes()
-            self._store_update_change_count()
-            self._store_status.setText(f"Added {new_name} to store")
-            self._store_selected()
-        else:
-            QMessageBox.warning(self, tr("Add Failed"), tr("Could not add item."))
+        new_stock = _copy.deepcopy(donor)
+        v = new_stock.get('value')
+        if isinstance(v, dict):
+            v['raw_q'] = new_key
+            p = v.get('payload')
+            if isinstance(p, dict):
+                p['body'] = new_key
+        stock_list.append(new_stock)
+        self._store_update_change_count()
+        self._store_status.setText(f"Added {new_name} to store")
+        self._store_selected()
 
     def _store_set_limit(self) -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             return
         store = self._store_get_selected_store()
-        if not store or not store.is_standard:
+        if not store:
             return
 
+        stock_list = store.get('stock_data_list', [])
         sel_rows = self._store_get_selected_items()
         if not sel_rows:
             QMessageBox.information(self, tr("Set Limit"), tr("Select item(s) first."))
             return
 
         new_limit = self._store_limit_spin.value()
-        body = self._store_parser_v2._body_data
         changed = 0
         for row in sel_rows:
-            if row < len(store.items):
-                item = store.items[row]
-                struct.pack_into('<I', body, item.offset + 0x12, new_limit)
-                item.trade_flags = new_limit
+            if row < len(stock_list):
+                stock_list[row]['raw_c'] = new_limit
                 changed += 1
 
         if changed:
-            self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
             self._store_update_change_count(changed)
             self._store_status.setText(f"Set limit={new_limit} on {changed} item(s)")
             self._store_selected()
 
     def _store_set_all_limits(self) -> None:
         store = self._store_get_selected_store()
-        if not store or not store.is_standard or not store.items:
-            QMessageBox.information(self, tr("Set All Limits"), tr("Select a standard store with items first."))
+        stock_list = store.get('stock_data_list', []) if store else []
+        if not stock_list:
+            QMessageBox.information(self, tr("Set All Limits"), tr("Select a store with items first."))
             return
 
         new_limit = self._store_limit_spin.value()
+        sname = store.get('string_key', '')
         reply = QMessageBox.question(
             self, tr("Set All Limits"),
-            f"Set purchase limit to {new_limit} for ALL {len(store.items)} items in {store.name}?",
+            f"Set purchase limit to {new_limit} for ALL {len(stock_list)} items in {sname}?",
             QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
         )
         if reply != QMessageBox.Yes:
             return
 
-        body = self._store_parser_v2._body_data
-        for item in store.items:
-            struct.pack_into('<I', body, item.offset + 0x12, new_limit)
-            item.trade_flags = new_limit
+        for stock in stock_list:
+            stock['raw_c'] = new_limit
 
-        self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
-        self._store_update_change_count(len(store.items))
-        self._store_status.setText(f"Set limit={new_limit} on all {len(store.items)} items")
+        self._store_update_change_count(len(stock_list))
+        self._store_status.setText(f"Set limit={new_limit} on all {len(stock_list)} items")
         self._store_selected()
 
     def _store_import_json(self) -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             QMessageBox.warning(self, tr("Import"), tr("Load store data first."))
             return
 
@@ -1098,10 +1129,11 @@ class StoreEditorTab(QWidget):
             return
 
         try:
+            import dmm_parser
             with open(path, 'r', encoding='utf-8') as f:
                 patch_data = json.load(f)
 
-            body = self._store_parser_v2._body_data
+            body = bytearray(dmm_parser.serialize_table('store_info', self._store_dmm))
             applied = 0
             skipped = 0
 
@@ -1128,8 +1160,7 @@ class StoreEditorTab(QWidget):
                         log.warning(tr("Patch mismatch at offset %d: expected %s, got %s"),
                                     offset, original.hex(), current.hex())
 
-            self._store_parser_v2._parse_all_stores()
-            self._store_parser._body_data = bytearray(self._store_parser_v2.get_body_bytes())
+            self._store_dmm = dmm_parser.parse_table('store_info', bytes(body), self._store_gh)
             self._store_update_change_count(applied)
             self._store_populate_list(self._store_search.text())
             self._store_selected()
@@ -1146,42 +1177,17 @@ class StoreEditorTab(QWidget):
             QMessageBox.critical(self, tr("Import Error"), str(e))
 
 
-    def _store_label_for_offset(self, offset: int) -> str:
-        parser = self._store_parser_v2
-        for store in parser.stores:
-            if not store.is_standard or not store.items:
-                continue
-            items_start = store.after_name + 51
-            items_end = items_start + store.item_count * 105
-            if not (items_start <= offset < items_end):
-                continue
-            item_idx = (offset - items_start) // 105
-            item_rel = (offset - items_start) % 105
-            if item_idx >= len(store.items):
-                break
-            item = store.items[item_idx]
-            item_name = parser.get_item_name(item.item_key)
-            if item_rel == 0x12:
-                return f"{store.name} - {item_name} (Limit)"
-            elif item_rel == 0x22:
-                return f"{store.name} - {item_name} (ItemID)"
-            elif item_rel == 0x5D:
-                return f"{store.name} - {item_name} (ItemID)"
-            else:
-                return f"{store.name} - {item_name} (+0x{item_rel:02X})"
-        return f"Offset 0x{offset:X}"
-
     def _store_build_changes(self, original: bytes, current: bytes) -> list:
         changes = []
         i = 0
-        while i < len(current):
+        while i < min(len(current), len(original)):
             if current[i] != original[i]:
                 start = i
-                while i < len(current) and current[i] != original[i]:
+                while i < min(len(current), len(original)) and current[i] != original[i]:
                     i += 1
                 changes.append({
                     "offset": start,
-                    "label": self._store_label_for_offset(start),
+                    "label": f"Offset 0x{start:X}",
                     "original": original[start:i].hex(),
                     "patched": current[start:i].hex(),
                 })
@@ -1189,17 +1195,17 @@ class StoreEditorTab(QWidget):
                 i += 1
         return changes
 
-
     def _store_export_json(self) -> None:
-        if not hasattr(self, '_store_parser_v2') or not self._store_parser_v2:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             QMessageBox.warning(self, tr("Export"), tr("Load store data first."))
             return
-        if not self._store_original_body:
+        if not hasattr(self, '_store_dmm_vanilla'):
             QMessageBox.warning(self, tr("Export"), tr("No original data to diff against."))
             return
 
-        current = self._store_parser_v2.get_body_bytes()
-        original = self._store_original_body
+        import dmm_parser
+        current = dmm_parser.serialize_table('store_info', self._store_dmm)
+        original = dmm_parser.serialize_table('store_info', self._store_dmm_vanilla)
 
         if len(current) != len(original):
             QMessageBox.warning(self, tr("Export"),
@@ -1245,7 +1251,7 @@ class StoreEditorTab(QWidget):
             f"Share this file — others drop it into NoSEModLoad/Json/.")
 
     def _store_apply(self) -> None:
-        if not self._store_parser:
+        if not hasattr(self, '_store_dmm') or not self._store_dmm:
             QMessageBox.warning(self, tr("Stores"), tr("Load store data first."))
             return
 
@@ -1253,7 +1259,7 @@ class StoreEditorTab(QWidget):
             QMessageBox.information(self, tr("No Changes"), tr("No modifications to apply."))
             return
 
-        game_path = self._store_parser.game_path
+        game_path = getattr(self, '_store_game_path', '') or self._game_path.strip()
         if not game_path or not os.path.isdir(game_path):
             QMessageBox.critical(self, tr("Invalid Game Path"),
                 f"Game path not found:\n{game_path}\n\n"
@@ -1266,19 +1272,16 @@ class StoreEditorTab(QWidget):
                 "Right-click the exe → Run as administrator")
             return
 
-        if hasattr(self, '_store_parser_v2') and self._store_parser_v2:
-            body_data = bytes(self._store_parser_v2.get_body_bytes())
-            header_data = self._store_parser_v2.get_header_bytes()
-        else:
-            body_data = bytes(self._store_parser._body_data)
-            header_data = self._store_original_header or self._store_parser._header_data
+        import dmm_parser
+        body_data = dmm_parser.serialize_table('store_info', self._store_dmm)
+        header_data = self._store_gh
 
         store_dir = f"{self._store_overlay_spin.value():04d}"
         reply = QMessageBox.question(
             self, tr("Apply Store Changes"),
             f"Pack modified storeinfo into {store_dir}/ override directory?\n\n"
             f"Data: pabgb={len(body_data):,} bytes, pabgh={len(header_data):,} bytes\n\n"
-            f"Uses pack_mod pipeline (same as ItemBuffs tab).\n"
+            f"Uses PackGroupBuilder overlay.\n"
             f"Original 0008/0.paz is NOT modified.\n"
             f"To undo: click Restore Original.\n\n"
             f"The game must be restarted for changes to take effect.",
@@ -1287,32 +1290,25 @@ class StoreEditorTab(QWidget):
         if reply != QMessageBox.Yes:
             return
 
-        self._store_status.setText(tr("Packing with pack_mod..."))
+        self._store_status.setText(tr("Packing overlay..."))
         QApplication.processEvents()
 
         try:
-            import crimson_rs.pack_mod
+            import crimson_rs
             import shutil
             import tempfile
 
+            INTERNAL_DIR = "gamedata/binary__/client/bin"
 
             with tempfile.TemporaryDirectory() as tmp_dir:
-                mod_dir = os.path.join(tmp_dir, "gamedata")
-                os.makedirs(mod_dir, exist_ok=True)
-                with open(os.path.join(mod_dir, "storeinfo.pabgb"), "wb") as f:
-                    f.write(body_data)
-                with open(os.path.join(mod_dir, "storeinfo.pabgh"), "wb") as f:
-                    f.write(header_data)
-
-                out_dir = os.path.join(tmp_dir, "output")
-                os.makedirs(out_dir, exist_ok=True)
-
-                crimson_rs.pack_mod.pack_mod(
-                    game_dir=game_path,
-                    mod_folder=tmp_dir,
-                    output_dir=out_dir,
-                    group_name=store_dir,
-                )
+                group_dir = os.path.join(tmp_dir, store_dir)
+                builder = crimson_rs.PackGroupBuilder(
+                    group_dir, crimson_rs.Compression.NONE,
+                    crimson_rs.Crypto.NONE)
+                builder.add_file(INTERNAL_DIR, "storeinfo.pabgb", body_data)
+                builder.add_file(INTERNAL_DIR, "storeinfo.pabgh", header_data)
+                pamt_bytes = bytes(builder.finish())
+                pamt_checksum = crimson_rs.parse_pamt_bytes(pamt_bytes)["checksum"]
 
                 papgt_path = os.path.join(game_path, "meta", "0.papgt")
                 papgt_backup = papgt_path + ".store_sebak"
@@ -1323,19 +1319,16 @@ class StoreEditorTab(QWidget):
                 if os.path.isdir(game_mod):
                     shutil.rmtree(game_mod)
                 os.makedirs(game_mod, exist_ok=True)
+                for fn in os.listdir(group_dir):
+                    shutil.copy2(os.path.join(group_dir, fn),
+                                 os.path.join(game_mod, fn))
 
-                shutil.copy2(
-                    os.path.join(out_dir, store_dir, "0.paz"),
-                    os.path.join(game_mod, "0.paz"),
-                )
-                shutil.copy2(
-                    os.path.join(out_dir, store_dir, "0.pamt"),
-                    os.path.join(game_mod, "0.pamt"),
-                )
-                shutil.copy2(
-                    os.path.join(out_dir, "meta", "0.papgt"),
-                    papgt_path,
-                )
+                papgt = crimson_rs.parse_papgt_file(papgt_path)
+                papgt["entries"] = [e for e in papgt["entries"]
+                                    if e.get("group_name") != store_dir]
+                papgt = crimson_rs.add_papgt_entry(
+                    papgt, store_dir, pamt_checksum, 0, 16383)
+                crimson_rs.write_papgt_file(papgt, papgt_path)
 
                 with open(os.path.join(game_mod, ".se_storemod"), "w") as mf:
                     mf.write("Created by CrimsonSaveEditor Stores tab\n")
@@ -1366,7 +1359,7 @@ class StoreEditorTab(QWidget):
                 pass
 
             QMessageBox.information(self, tr("Applied Successfully"),
-                f"Packed to {store_dir}/ via pack_mod ({paz_size:,} bytes)\n"
+                f"Packed to {store_dir}/ ({paz_size:,} bytes)\n"
                 f"Original 0008/0.paz untouched{papgt_verify}\n\n"
                 f"Restart the game for changes to take effect.\n"
                 f"To undo: click 'Restore Original'.")
@@ -1725,193 +1718,133 @@ class SpawnTab(QWidget):
 
         try:
             import crimson_rs
+            import dmm_parser as _dmp_spawn
+            import copy as _copy_spawn
 
             dir_path = "gamedata/binary__/client/bin"
-            body = crimson_rs.extract_file(game_path, "0008", dir_path,
-                                           "terrainregionautospawninfo.pabgb")
-            schema = crimson_rs.extract_file(game_path, "0008", dir_path,
-                                              "terrainregionautospawninfo.pabgh")
+            body = bytes(crimson_rs.extract_file(game_path, "0008", dir_path,
+                                           "terrainregionautospawninfo.pabgb"))
+            schema = bytes(crimson_rs.extract_file(game_path, "0008", dir_path,
+                                              "terrainregionautospawninfo.pabgh"))
 
+            self._spawn_dmm = _dmp_spawn.parse_table('terrain_region_auto_spawn_info', body, schema)
+            self._spawn_dmm_vanilla = _copy_spawn.deepcopy(self._spawn_dmm)
             self._spawn_data = bytearray(body)
             self._spawn_original = bytes(body)
-            self._spawn_schema = bytes(schema)
+            self._spawn_schema = schema
             self._spawn_modified = False
             self._spawn_changes_label.setText("")
 
-            import struct as _st
-            _c16 = _st.unpack_from('<H', self._spawn_schema, 0)[0]
-            if 2 + _c16 * 8 == len(self._spawn_schema):
-                count = _c16
-                _idx_off = 2
-            else:
-                count = _st.unpack_from('<I', self._spawn_schema, 0)[0]
-                _idx_off = 4
-            idx = {}
-            for i in range(count):
-                _pos = _idx_off + i * 8
-                if _pos + 8 > len(self._spawn_schema):
-                    break
-                k = _st.unpack_from('<I', self._spawn_schema, _pos)[0]
-                o = _st.unpack_from('<I', self._spawn_schema, _pos + 4)[0]
-                idx[k] = o
-
-            sorted_offs = sorted(set(idx.values())) + [len(self._spawn_data)]
-
-            MARKER = b'\x0A\x36\xC1\xE0'
             elements = []
 
-            for region_key, entry_off in sorted(idx.items(), key=lambda x: x[1]):
-                ni = sorted_offs.index(entry_off) + 1
-                entry_end = sorted_offs[ni]
-                raw = self._spawn_data[entry_off:entry_end]
-
-                if len(raw) < 8:
-                    continue
-                name_len = _st.unpack_from('<I', raw, 4)[0]
-                region_name = raw[8:8 + name_len].decode('utf-8', errors='replace').rstrip('\x00')
-
-                positions = []
-                search_start = 0
-                while True:
-                    pos = raw.find(MARKER, search_start)
-                    if pos < 0:
-                        break
-                    positions.append(pos)
-                    search_start = pos + 4
-
-                for mi in range(len(positions) - 1):
-                    m_off = positions[mi]
-                    next_off = positions[mi + 1]
-                    elem_size = next_off - m_off
-
-                    if elem_size != 81:
-                        continue
-
-                    abs_marker = entry_off + m_off
-                    timer_ms = _st.unpack_from('<I', self._spawn_data, abs_marker + 0x23)[0]
-                    char_key = _st.unpack_from('<I', self._spawn_data, abs_marker + 0x2F)[0]
-                    spawn_count = _st.unpack_from('<I', self._spawn_data, abs_marker + 0x3B)[0]
-
-                    elements.append({
-                        'region_key': region_key,
-                        'region_name': region_name,
-                        'char_key': char_key,
-                        'spawn_count': spawn_count,
-                        'timer_ms': timer_ms,
-                        'count_offset': abs_marker + 0x3B,
-                        'timer_offset': abs_marker + 0x23,
-                        'source': 'terrain',
-                    })
+            for region in self._spawn_dmm:
+                region_key = region.get('key', 0)
+                region_name = region.get('string_key', '')
+                for spawn_entry in region.get('spawn_list', []):
+                    for spline in spawn_entry.get('spline_list', []):
+                        for inner in spline.get('inner_list', []):
+                            char_key = inner.get('raw_a', 0)
+                            spawn_count = inner.get('flag_a', 0)
+                            timer_ms = spline.get('raw_qword', 0)
+                            elements.append({
+                                'region_key': region_key,
+                                'region_name': region_name,
+                                'char_key': char_key,
+                                'spawn_count': spawn_count,
+                                'timer_ms': timer_ms,
+                                'vanilla_count': spawn_count,
+                                'vanilla_timer': timer_ms,
+                                'inner_ref': inner,
+                                'spline_ref': spline,
+                                'source': 'terrain',
+                            })
 
             self._spawn_elements = elements
+            log.info("Loaded %d terrain spawn entries via dmm_parser", len(elements))
 
             self._spawn_char_names = {}
             try:
-                import crimson_rs
-                char_data = crimson_rs.extract_file(
-                    game_path, "0008", dir_path, "characterinfo.pabgh")
-                char_body = crimson_rs.extract_file(
-                    game_path, "0008", dir_path, "characterinfo.pabgb")
-                _c16 = _st.unpack_from('<H', char_data, 0)[0]
-                if 2 + _c16 * 8 == len(char_data):
-                    char_count = _c16
-                    _idx_start = 2
-                else:
-                    char_count = _st.unpack_from('<I', char_data, 0)[0]
-                    _idx_start = 4
-                char_offsets = {}
-                for ci in range(char_count):
-                    _pos = _idx_start + ci * 8
-                    if _pos + 8 > len(char_data):
-                        break
-                    ck = _st.unpack_from('<I', char_data, _pos)[0]
-                    co = _st.unpack_from('<I', char_data, _pos + 4)[0]
-                    char_offsets[ck] = co
-                for ck, co in char_offsets.items():
-                    if co + 8 > len(char_body):
-                        continue
-                    nlen = _st.unpack_from('<I', char_body, co + 4)[0]
-                    if nlen > 200 or co + 8 + nlen > len(char_body):
-                        continue
-                    raw_name = char_body[co + 8:co + 8 + nlen]
-                    name = raw_name.decode('utf-8', errors='replace').rstrip('\x00')
-                    clean = name
-                    parts = clean.rsplit('_', 1)
+                char_gb = bytes(crimson_rs.extract_file(
+                    game_path, "0008", dir_path, "characterinfo.pabgb"))
+                char_gh = bytes(crimson_rs.extract_file(
+                    game_path, "0008", dir_path, "characterinfo.pabgh"))
+                char_entries = _dmp_spawn.parse_table('character_info', char_gb, char_gh)
+                for ce in char_entries:
+                    name = ce.get('string_key', '')
+                    parts = name.rsplit('_', 1)
                     if len(parts) == 2 and parts[1].isdigit():
-                        clean = parts[0]
-                    self._spawn_char_names[ck] = clean.replace('_', ' ')
-                log.info("Loaded %d character names", len(self._spawn_char_names))
+                        name = parts[0]
+                    self._spawn_char_names[ce['key']] = name.replace('_', ' ')
+                log.info("Loaded %d character names via dmm_parser", len(self._spawn_char_names))
             except Exception as _ce:
                 log.warning(tr("Could not load character names: %s"), _ce)
 
-            try:
-                from terrain_spawn_parser import get_verified_rate_offsets
-                verified_rates = get_verified_rate_offsets(bytes(self._spawn_data), self._spawn_schema)
-                for off, val, rname in verified_rates:
-                    elements.append({
-                        'region_key': 0,
-                        'region_name': rname,
-                        'char_key': 0,
-                        'spawn_count': val,
-                        'timer_ms': -1,
-                        'count_offset': off,
-                        'timer_offset': -1,
-                        'source': 'rate',
-                        'rate_value': val,
-                    })
-                log.info("Loaded %d verified open-world spawn rates", len(verified_rates))
-            except Exception as _re:
-                log.exception("Unhandled exception")
-                log.warning(tr("Could not load spawn rates: %s"), _re)
+            import ctypes as _ct_rates
+            rate_count = 0
+            for region in self._spawn_dmm:
+                rkey = region.get('key', 0)
+                rname = region.get('string_key', '')
+                for se in region.get('spawn_list', []):
+                    for sp in se.get('spline_list', []):
+                        rate_u32 = sp.get('raw_g', 0)
+                        rate_f = _ct_rates.c_float.from_buffer_copy(
+                            _ct_rates.c_uint32(rate_u32 & 0xFFFFFFFF)).value
+                        elements.append({
+                            'region_key': rkey,
+                            'region_name': rname,
+                            'char_key': 0,
+                            'spawn_count': rate_f,
+                            'timer_ms': -1,
+                            'source': 'rate',
+                            'rate_value': rate_f,
+                            'vanilla_rate': rate_f,
+                            'spline_ref': sp,
+                        })
+                        rate_count += 1
+            log.info("Loaded %d spawn rates via dmm_parser (spline.raw_g)", rate_count)
 
             try:
-                fnode_body = crimson_rs.extract_file(
-                    game_path, "0008", dir_path, "factionnode.pabgb")
-                fnode_gh = crimson_rs.extract_file(
-                    game_path, "0008", dir_path, "factionnode.pabgh")
+                fnode_body = bytes(crimson_rs.extract_file(
+                    game_path, "0008", dir_path, "factionnode.pabgb"))
+                fnode_gh = bytes(crimson_rs.extract_file(
+                    game_path, "0008", dir_path, "factionnode.pabgh"))
 
+                self._spawn_fnode_dmm = _dmp_spawn.parse_table('faction_node_info', fnode_body, fnode_gh)
+                self._spawn_fnode_dmm_vanilla = _copy_spawn.deepcopy(self._spawn_fnode_dmm)
                 self._spawn_fnode_ops_data = bytearray(fnode_body)
-                self._spawn_fnode_ops_original = bytes(fnode_body)
-                self._spawn_fnode_ops_schema = bytes(fnode_gh)
-
-                import tempfile as _tf2
-                with _tf2.NamedTemporaryFile(suffix='.pabgb', delete=False) as _fb:
-                    _fb.write(self._spawn_fnode_ops_data)
-                    _fb_path = _fb.name
-                with _tf2.NamedTemporaryFile(suffix='.pabgh', delete=False) as _fg:
-                    _fg.write(self._spawn_fnode_ops_schema)
-                    _fg_path = _fg.name
-                try:
-                    from factionnode_operator_parser import parse_operator_counts
-                    fnode_results, _fn_fails = parse_operator_counts(_fb_path, _fg_path)
-                finally:
-                    os.unlink(_fb_path)
-                    os.unlink(_fg_path)
+                self._spawn_fnode_ops_original = fnode_body
+                self._spawn_fnode_ops_schema = fnode_gh
 
                 fnode_ops_count = 0
-                for entry in fnode_results:
-                    for si, sched in enumerate(entry.get('schedules', [])):
-                        node_name = entry.get('name', '').replace('Node_', '').replace('_', ' ')
-                        sched_label = f"{node_name} [sched {si}]" if len(entry.get('schedules', [])) > 1 else node_name
+                for entry in self._spawn_fnode_dmm:
+                    node_name = entry.get('string_key', '').replace('Node_', '').replace('_', ' ')
+                    fsl = entry.get('faction_schedule_list', [])
+                    for si, sched in enumerate(fsl):
+                        rde = sched.get('raw_data_ext', {})
+                        max_op = rde.get('flag', 0)
+                        sched_label = f"{node_name} [sched {si}]" if len(fsl) > 1 else node_name
+                        sil = sched.get('slot_inner_list', [])
+                        sub_elems = [{'count': sl.get('lookup_a', 0), 'time': sl.get('raw_a', 0),
+                                      'slot_ref': sl} for sl in sil]
                         elements.append({
                             'region_key': entry.get('key', 0),
                             'region_name': sched_label,
                             'char_key': 0,
-                            'spawn_count': sched['max_operator_count'],
-                            'timer_ms': sched.get('period_time', 0),
-                            'count_offset': sched['max_operator_offset'],
-                            'timer_offset': -1,
+                            'spawn_count': max_op,
+                            'timer_ms': 0,
+                            'vanilla_count': max_op,
+                            'vanilla_timer': 0,
                             'source': 'fnode_ops',
-                            'min_op': sched.get('min_operator_count', -1),
-                            'min_op_offset': sched.get('min_operator_offset', -1),
-                            'sub_elements': sched.get('sub_elements', []),
-                            'worker_count': entry.get('worker_count', -1),
-                            'worker_count_offset': entry.get('worker_count_offset', -1),
+                            'sched_ref': sched,
+                            'rde_ref': rde,
+                            'min_op': -1,
+                            'vanilla_min_op': -1,
+                            'sub_elements': sub_elems,
+                            'worker_count': -1,
                         })
                         fnode_ops_count += 1
 
-                log.info("Loaded %d factionnode operator schedules (maxOp)", fnode_ops_count)
-
+                log.info("Loaded %d factionnode operator schedules via dmm_parser", fnode_ops_count)
 
             except Exception as _foe:
                 log.exception("Unhandled exception")
@@ -1965,11 +1898,11 @@ class SpawnTab(QWidget):
                     continue
             filtered.append(el)
 
+        self._spawn_filtered = filtered
         self._spawn_table.setRowCount(len(filtered))
         for row, el in enumerate(filtered):
             src = el.get('source', 'terrain')
             is_terrain = src == 'terrain'
-            is_fnode = src == 'fnode'
 
             src_labels = {'terrain': 'Animal', 'fnode_ops': 'Camp', 'rate': 'SpawnRate'}
             src_label = src_labels.get(src, src)
@@ -1981,7 +1914,7 @@ class SpawnTab(QWidget):
                 item.setForeground(QColor(80, 160, 255))
             elif is_fnode_ops:
                 item.setForeground(QColor(180, 130, 100))
-            item.setData(Qt.UserRole, el)
+            item.setData(Qt.UserRole, row)
             self._spawn_table.setItem(row, 0, item)
 
             item = QTableWidgetItem(str(el['region_key']))
@@ -2004,19 +1937,19 @@ class SpawnTab(QWidget):
             if is_rate:
                 rate_val = el.get('rate_value', el.get('spawn_count', 1.0))
                 item = QTableWidgetItem(f"{rate_val:.2f}")
-                orig_rate = struct.unpack_from('<f', self._spawn_original, el['count_offset'])[0]
+                orig_rate = el.get('vanilla_rate', rate_val)
                 if abs(rate_val - orig_rate) > 0.001:
                     item.setBackground(QColor(20, 40, 80))
                 item.setToolTip(f"Spawn rate (vanilla: {orig_rate:.2f})")
             elif is_terrain:
                 item = QTableWidgetItem(str(el['spawn_count']))
-                orig = struct.unpack_from('<I', self._spawn_original, el['count_offset'])[0]
+                orig = el.get('vanilla_count', el['spawn_count'])
                 if el['spawn_count'] != orig:
                     item.setBackground(QColor(60, 40, 20))
             elif is_fnode_ops:
                 item = QTableWidgetItem(str(el['spawn_count']))
-                orig_fo = self._spawn_fnode_ops_original[el['count_offset']]
-                if el['spawn_count'] != orig_fo:
+                vanilla_fo = el.get('vanilla_count', el['spawn_count'])
+                if el['spawn_count'] != vanilla_fo:
                     item.setBackground(QColor(60, 30, 10))
             else:
                 item = QTableWidgetItem("?")
@@ -2027,11 +1960,9 @@ class SpawnTab(QWidget):
             if is_fnode_ops:
                 min_op = el.get('min_op', -1)
                 item = QTableWidgetItem(str(min_op))
-                min_op_off = el.get('min_op_offset', -1)
-                if min_op_off >= 0:
-                    orig_mo = struct.unpack_from('<I', self._spawn_fnode_ops_original, min_op_off)[0]
-                    if min_op != orig_mo:
-                        item.setBackground(QColor(60, 30, 10))
+                vanilla_min = el.get('vanilla_min_op', min_op)
+                if min_op != vanilla_min:
+                    item.setBackground(QColor(60, 30, 10))
             else:
                 item = QTableWidgetItem("")
                 item.setFlags(item.flags() & ~Qt.ItemIsEditable)
@@ -2040,23 +1971,12 @@ class SpawnTab(QWidget):
 
             if is_fnode_ops:
                 sub_elems = el.get('sub_elements', [])
-                parts = []
-                changed = False
-                for se in sub_elems:
-                    c = se['count']
-                    parts.append(str(c))
-                    off = se.get('count_offset', -1)
-                    if off >= 0 and hasattr(self, '_spawn_fnode_ops_original') and self._spawn_fnode_ops_original:
-                        orig_c = self._spawn_fnode_ops_original[off]
-                        if c != orig_c:
-                            changed = True
+                parts = [str(se.get('count', 0)) for se in sub_elems]
                 display = ' / '.join(parts)
                 item = QTableWidgetItem(display)
                 item.setFlags(item.flags() & ~Qt.ItemIsEditable)
-                if changed:
-                    item.setBackground(QColor(80, 20, 40))
                 item.setToolTip(
-                    f"Per-slot operator counts (vanilla typically 12/15/0)\n"
+                    f"Per-slot operator counts\n"
                     f"Use 'Multiply Sub-Slot Counts' button to change")
             else:
                 item = QTableWidgetItem("")
@@ -2064,13 +1984,8 @@ class SpawnTab(QWidget):
             self._spawn_table.setItem(row, 7, item)
 
             if is_fnode_ops:
-                wc = el.get('worker_count', -1)
-                item = QTableWidgetItem(str(wc) if wc >= 0 else "?")
-                wc_off = el.get('worker_count_offset', -1)
-                if wc_off >= 0 and hasattr(self, '_spawn_fnode_ops_original') and self._spawn_fnode_ops_original:
-                    orig_wc = self._spawn_fnode_ops_original[wc_off]
-                    if wc != orig_wc:
-                        item.setBackground(QColor(40, 50, 30))
+                item = QTableWidgetItem("—")
+                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
             else:
                 item = QTableWidgetItem("")
                 item.setFlags(item.flags() & ~Qt.ItemIsEditable)
@@ -2078,7 +1993,7 @@ class SpawnTab(QWidget):
 
             if is_terrain:
                 item = QTableWidgetItem(str(el['timer_ms']))
-                orig_t = struct.unpack_from('<I', self._spawn_original, el['timer_offset'])[0]
+                orig_t = el.get('vanilla_timer', el['timer_ms'])
                 if el['timer_ms'] != orig_t:
                     item.setBackground(QColor(60, 40, 20))
             else:
@@ -2099,9 +2014,10 @@ class SpawnTab(QWidget):
         item0 = self._spawn_table.item(row, 0)
         if not item0:
             return
-        el = item0.data(Qt.UserRole)
-        if not el:
+        fidx = item0.data(Qt.UserRole)
+        if fidx is None or not hasattr(self, '_spawn_filtered') or fidx >= len(self._spawn_filtered):
             return
+        el = self._spawn_filtered[fidx]
         src = el.get('source', '')
         if src not in ('terrain', 'fnode_ops', 'rate'):
             return
@@ -2112,47 +2028,18 @@ class SpawnTab(QWidget):
             except ValueError:
                 return
             new_val = max(0.01, min(new_val, 20.0))
-            off = el.get('count_offset', -1)
-            if off >= 0:
-                struct.pack_into('<f', self._spawn_data, off, new_val)
-                el['spawn_count'] = new_val
-                el['rate_value'] = new_val
-                self._spawn_modified = True
-                self._spawn_update_changes()
+            sp = el.get('spline_ref')
+            if sp is not None:
+                import ctypes as _ct_re
+                sp['raw_g'] = _ct_re.c_uint32.from_buffer_copy(_ct_re.c_float(new_val)).value
+            el['spawn_count'] = new_val
+            el['rate_value'] = new_val
+            self._spawn_modified = True
+            self._spawn_update_changes()
             return
 
         cell = self._spawn_table.item(row, col)
         if not cell:
-            return
-
-        if src == 'fnode_ops' and col == 8:
-            try:
-                new_val = int(cell.text())
-            except ValueError:
-                return
-            new_val = max(0, min(new_val, 255))
-            wc_off = el.get('worker_count_offset', -1)
-            if wc_off >= 0:
-                self._spawn_fnode_ops_data[wc_off] = new_val
-                el['worker_count'] = new_val
-                for other in self._spawn_elements:
-                    if other.get('source') == 'fnode_ops' and other.get('region_key') == el.get('region_key'):
-                        other['worker_count'] = new_val
-                self._spawn_modified = True
-                self._spawn_update_changes()
-            return
-
-        if src == 'fnode_info' and col == 5:
-            try:
-                new_val = float(cell.text())
-            except ValueError:
-                return
-            if new_val < 0:
-                new_val = 0.0
-            struct.pack_into('<f', self._spawn_fnode_ops_data, el['count_offset'], new_val)
-            el['spawn_count'] = round(new_val, 2)
-            self._spawn_modified = True
-            self._spawn_update_changes()
             return
 
         if src == 'fnode_ops' and col == 5:
@@ -2161,37 +2048,18 @@ class SpawnTab(QWidget):
             except ValueError:
                 return
             new_val = max(1, min(new_val, 255))
-            self._spawn_fnode_ops_data[el['count_offset']] = new_val
+            rde = el.get('rde_ref')
+            if rde is not None:
+                rde['flag'] = new_val
             el['spawn_count'] = new_val
             self._spawn_modified = True
             self._spawn_update_changes()
             return
 
         if src == 'fnode_ops' and col == 6:
-            try:
-                new_val = int(cell.text())
-            except ValueError:
-                return
-            new_val = max(0, min(new_val, 255))
-            min_off = el.get('min_op_offset', -1)
-            if min_off >= 0:
-                self._spawn_fnode_ops_data[min_off] = new_val
-                el['min_op'] = new_val
-                self._spawn_modified = True
-                self._spawn_update_changes()
             return
 
-        if src == 'fnode' and col == 5:
-            try:
-                new_val = float(cell.text())
-            except ValueError:
-                return
-            if new_val < 0:
-                new_val = 0.0
-            struct.pack_into('<f', self._spawn_node_data, el['count_offset'], new_val)
-            el['spawn_count'] = round(new_val, 2)
-            self._spawn_modified = True
-            self._spawn_update_changes()
+        if src == 'fnode_ops' and col == 8:
             return
 
         try:
@@ -2205,10 +2073,14 @@ class SpawnTab(QWidget):
             new_val = 100
 
         if col == 5:
-            struct.pack_into('<I', self._spawn_data, el['count_offset'], new_val)
+            inner = el.get('inner_ref')
+            if inner is not None:
+                inner['flag_a'] = new_val
             el['spawn_count'] = new_val
         elif col == 9:
-            struct.pack_into('<I', self._spawn_data, el['timer_offset'], new_val)
+            spline = el.get('spline_ref')
+            if spline is not None:
+                spline['raw_qword'] = new_val
             el['timer_ms'] = new_val
 
         self._spawn_modified = True
@@ -2243,27 +2115,26 @@ class SpawnTab(QWidget):
                 item0 = self._spawn_table.item(idx.row(), 0)
                 if not item0:
                     continue
-                el = item0.data(Qt.UserRole)
-                if not el or el.get('count_offset', -1) < 0:
+                fidx = item0.data(Qt.UserRole)
+                if fidx is None or not hasattr(self, '_spawn_filtered') or fidx >= len(self._spawn_filtered):
+                    continue
+                el = self._spawn_filtered[fidx]
+                if not el:
                     continue
                 src = el.get('source', '')
                 if src == 'terrain':
                     iv = min(int(val), 100)
-                    struct.pack_into('<I', self._spawn_data, el['count_offset'], iv)
+                    inner = el.get('inner_ref')
+                    if inner is not None:
+                        inner['flag_a'] = iv
                     el['spawn_count'] = iv
-                    changed += 1
-                elif src == 'fnode':
-                    struct.pack_into('<f', self._spawn_node_data, el['count_offset'], val)
-                    el['spawn_count'] = round(val, 2)
                     changed += 1
                 elif src == 'fnode_ops':
                     iv = max(1, min(int(val), 255))
-                    self._spawn_fnode_ops_data[el['count_offset']] = iv
+                    rde = el.get('rde_ref')
+                    if rde is not None:
+                        rde['flag'] = iv
                     el['spawn_count'] = iv
-                    changed += 1
-                elif src == 'fnode_info':
-                    struct.pack_into('<f', self._spawn_fnode_ops_data, el['count_offset'], val)
-                    el['spawn_count'] = round(val, 2)
                     changed += 1
             if changed:
                 self._spawn_modified = True
@@ -2284,9 +2155,11 @@ class SpawnTab(QWidget):
                 if not item0:
                     continue
                 el = item0.data(Qt.UserRole)
-                if not el or el.get('source') != 'terrain' or el.get('timer_offset', -1) < 0:
+                if not el or el.get('source') != 'terrain':
                     continue
-                struct.pack_into('<I', self._spawn_data, el['timer_offset'], val)
+                spline = el.get('spline_ref')
+                if spline is not None:
+                    spline['raw_qword'] = val
                 el['timer_ms'] = val
                 changed += 1
             if changed:
@@ -2306,28 +2179,25 @@ class SpawnTab(QWidget):
                 item0 = self._spawn_table.item(idx.row(), 0)
                 if not item0:
                     continue
-                el = item0.data(Qt.UserRole)
-                if not el or el.get('count_offset', -1) < 0:
+                fidx = item0.data(Qt.UserRole)
+                if fidx is None or not hasattr(self, '_spawn_filtered') or fidx >= len(self._spawn_filtered):
+                    continue
+                el = self._spawn_filtered[fidx]
+                if not el:
                     continue
                 src = el.get('source', '')
                 if src == 'terrain':
                     new_val = min(int(el['spawn_count'] * val), 100)
-                    struct.pack_into('<I', self._spawn_data, el['count_offset'], new_val)
-                    el['spawn_count'] = new_val
-                    changed += 1
-                elif src == 'fnode':
-                    new_val = round(el['spawn_count'] * val, 2)
-                    struct.pack_into('<f', self._spawn_node_data, el['count_offset'], new_val)
+                    inner = el.get('inner_ref')
+                    if inner is not None:
+                        inner['flag_a'] = new_val
                     el['spawn_count'] = new_val
                     changed += 1
                 elif src == 'fnode_ops':
                     new_val = max(1, min(int(el['spawn_count'] * val), 255))
-                    self._spawn_fnode_ops_data[el['count_offset']] = new_val
-                    el['spawn_count'] = new_val
-                    changed += 1
-                elif src == 'fnode_info':
-                    new_val = round(el['spawn_count'] * val, 2)
-                    struct.pack_into('<f', self._spawn_fnode_ops_data, el['count_offset'], new_val)
+                    rde = el.get('rde_ref')
+                    if rde is not None:
+                        rde['flag'] = new_val
                     el['spawn_count'] = new_val
                     changed += 1
             if changed:
@@ -2337,32 +2207,18 @@ class SpawnTab(QWidget):
                 self._spawn_status.setText(f"Multiplied {changed} entries by {val}x")
 
     def _spawn_update_changes(self):
-        if not self._spawn_original or not self._spawn_data:
+        if not self._spawn_elements:
             return
         changes = 0
         for el in self._spawn_elements:
             src = el.get('source', '')
-            if src == 'terrain' and el['count_offset'] >= 0:
-                orig_c = struct.unpack_from('<I', self._spawn_original, el['count_offset'])[0]
-                orig_t = struct.unpack_from('<I', self._spawn_original, el['timer_offset'])[0]
-                if el['spawn_count'] != orig_c or el['timer_ms'] != orig_t:
+            if src == 'terrain':
+                if el['spawn_count'] != el.get('vanilla_count', el['spawn_count']):
                     changes += 1
-            elif src == 'fnode' and el['count_offset'] >= 0 and hasattr(self, '_spawn_node_original'):
-                orig_f = struct.unpack_from('<f', self._spawn_node_original, el['count_offset'])[0]
-                if abs(el['spawn_count'] - orig_f) > 0.01:
+                elif el['timer_ms'] != el.get('vanilla_timer', el['timer_ms']):
                     changes += 1
-            elif src == 'fnode_ops' and el['count_offset'] >= 0 and hasattr(self, '_spawn_fnode_ops_original'):
-                orig_fo = self._spawn_fnode_ops_original[el['count_offset']]
-                if el['spawn_count'] != orig_fo:
-                    changes += 1
-                min_off = el.get('min_op_offset', -1)
-                if min_off >= 0:
-                    orig_mo = self._spawn_fnode_ops_original[min_off]
-                    if el.get('min_op', -1) != orig_mo:
-                        changes += 1
-            elif src == 'fnode_info' and el['count_offset'] >= 0 and hasattr(self, '_spawn_fnode_ops_original'):
-                orig_fi = struct.unpack_from('<f', self._spawn_fnode_ops_original, el['count_offset'])[0]
-                if abs(el['spawn_count'] - round(orig_fi, 2)) > 0.01:
+            elif src == 'fnode_ops':
+                if el['spawn_count'] != el.get('vanilla_count', el['spawn_count']):
                     changes += 1
         self._spawn_changes_label.setText(f"{changes} change(s)" if changes else "")
 
@@ -2378,32 +2234,22 @@ class SpawnTab(QWidget):
             src = el.get('source', '')
             if source_filter and src != source_filter:
                 continue
-            if src == 'terrain' and el['count_offset'] >= 0:
+            if src == 'terrain':
                 old = el['spawn_count']
-                new_val = min(old * mult, 100)
+                new_val = min(int(old * mult), 100)
                 if new_val != old:
-                    struct.pack_into('<I', self._spawn_data, el['count_offset'], new_val)
+                    inner = el.get('inner_ref')
+                    if inner is not None:
+                        inner['flag_a'] = new_val
                     el['spawn_count'] = new_val
                     count += 1
-            elif src == 'fnode' and el['count_offset'] >= 0:
-                old = el['spawn_count']
-                new_val = round(old * mult, 2)
-                if new_val != old:
-                    struct.pack_into('<f', self._spawn_node_data, el['count_offset'], new_val)
-                    el['spawn_count'] = new_val
-                    count += 1
-            elif src == 'fnode_ops' and el['count_offset'] >= 0:
+            elif src == 'fnode_ops':
                 old = el['spawn_count']
                 new_val = max(1, min(int(old * mult), 255))
                 if new_val != old:
-                    self._spawn_fnode_ops_data[el['count_offset']] = new_val
-                    el['spawn_count'] = new_val
-                    count += 1
-            elif src == 'fnode_info' and el['count_offset'] >= 0:
-                old = el['spawn_count']
-                new_val = round(old * mult, 2)
-                if new_val != old:
-                    struct.pack_into('<f', self._spawn_fnode_ops_data, el['count_offset'], new_val)
+                    rde = el.get('rde_ref')
+                    if rde is not None:
+                        rde['flag'] = new_val
                     el['spawn_count'] = new_val
                     count += 1
 
@@ -2433,21 +2279,21 @@ class SpawnTab(QWidget):
             fill_value = min(active_counts) if active_counts else 0
 
             for se in sub_elems:
-                off = se.get('count_offset', -1)
-                if off < 0:
+                slot = se.get('slot_ref')
+                if slot is None:
                     continue
                 old = se['count']
                 if old > 20:
                     continue
                 if old == 0 and fill_value > 0:
-                    new_val = min(fill_value * mult, 255)
-                    self._spawn_fnode_ops_data[off] = new_val
+                    new_val = int(min(fill_value * mult, 255))
+                    slot['lookup_a'] = new_val
                     se['count'] = new_val
                     dormant_filled += 1
                     count_changed += 1
                 elif old > 0:
-                    new_val = min(old * mult, 255)
-                    self._spawn_fnode_ops_data[off] = new_val
+                    new_val = int(min(old * mult, 255))
+                    slot['lookup_a'] = new_val
                     se['count'] = new_val
                     count_changed += 1
 
@@ -2459,7 +2305,7 @@ class SpawnTab(QWidget):
             f"({dormant_filled} dormant slots filled)")
 
     def _spawn_halve_sub_times(self):
-        if not hasattr(self, '_spawn_fnode_ops_data') or not self._spawn_fnode_ops_data:
+        if not self._spawn_elements:
             QMessageBox.information(self, tr("SpawnEdit"), tr("Load spawn data first."))
             return
 
@@ -2468,13 +2314,14 @@ class SpawnTab(QWidget):
             if el.get('source') != 'fnode_ops':
                 continue
             for se in el.get('sub_elements', []):
-                off = se.get('time_offset', -1)
-                if off < 0:
+                old = se.get('time', 0)
+                if old <= 0:
                     continue
-                old = se['time']
                 new_val = max(old // 2, 10)
                 if new_val != old:
-                    struct.pack_into('<I', self._spawn_fnode_ops_data, off, new_val)
+                    slot = se.get('slot_ref')
+                    if slot is not None:
+                        slot['raw_a'] = new_val
                     se['time'] = new_val
                     count += 1
 
@@ -2484,29 +2331,11 @@ class SpawnTab(QWidget):
         self._spawn_status.setText(f"Halved {count} sub-slot time values")
 
     def _spawn_multiply_all_minop(self):
-        if not hasattr(self, '_spawn_fnode_ops_data') or not self._spawn_fnode_ops_data:
+        if not self._spawn_elements:
             QMessageBox.information(self, tr("SpawnEdit"), tr("Load spawn data first."))
             return
 
-        mult = self._spawn_multiplier.value()
-        count = 0
-        for el in self._spawn_elements:
-            if el.get('source') != 'fnode_ops':
-                continue
-            min_off = el.get('min_op_offset', -1)
-            if min_off < 0:
-                continue
-            old = el.get('min_op', 0)
-            new_val = max(1, min(int(old * mult), 255))
-            if new_val != old:
-                self._spawn_fnode_ops_data[min_off] = new_val
-                el['min_op'] = new_val
-                count += 1
-
-        self._spawn_modified = True
-        self._spawn_filter()
-        self._spawn_update_changes()
-        self._spawn_status.setText(f"Multiplied {count} MinOp values by {mult}x")
+        self._spawn_status.setText("MinOp not mapped in current game data")
 
     def _spawn_increase_all_smart(self):
         if not self._spawn_data:
@@ -2516,94 +2345,50 @@ class SpawnTab(QWidget):
         mult = self._spawn_multiplier.value()
         results = []
 
-        if hasattr(self, '_spawn_fnode_ops_data') and self._spawn_fnode_ops_data:
-            camp_max = 0
-            for el in self._spawn_elements:
-                if el.get('source') != 'fnode_ops': continue
-                off = el.get('count_offset', -1)
-                if off < 0: continue
-                old = el.get('spawn_count', 0)
-                new_val = max(1, min(int(old * mult), 255))
-                if new_val != old:
-                    self._spawn_fnode_ops_data[off] = new_val
-                    el['spawn_count'] = new_val
-                    camp_max += 1
-            if camp_max: results.append(f"{camp_max} camp MaxOp x{mult}")
+        camp_max = 0
+        for el in self._spawn_elements:
+            if el.get('source') != 'fnode_ops': continue
+            old = el.get('spawn_count', 0)
+            new_val = max(1, min(int(old * mult), 255))
+            if new_val != old:
+                rde = el.get('rde_ref')
+                if rde is not None:
+                    rde['flag'] = new_val
+                el['spawn_count'] = new_val
+                camp_max += 1
+        if camp_max: results.append(f"{camp_max} camp MaxOp x{mult}")
 
-            camp_min = 0
-            for el in self._spawn_elements:
-                if el.get('source') != 'fnode_ops': continue
-                min_off = el.get('min_op_offset', -1)
-                if min_off < 0: continue
-                old = el.get('min_op', 0)
-                new_val = max(1, min(int(old * mult), 255))
-                if new_val != old:
-                    self._spawn_fnode_ops_data[min_off] = new_val
-                    el['min_op'] = new_val
-                    camp_min += 1
-            if camp_min: results.append(f"{camp_min} camp MinOp x{mult}")
-
-            sub_count = 0
-            for el in self._spawn_elements:
-                if el.get('source') != 'fnode_ops': continue
-                sub_offsets = el.get('sub_slot_offsets', [])
-                sub_values = el.get('sub_slot_values', [])
-                for i, (soff, sval) in enumerate(zip(sub_offsets, sub_values)):
-                    if soff < 0 or sval == 0: continue
-                    new_val = max(1, min(int(sval * mult), 255))
-                    if new_val != sval:
-                        self._spawn_fnode_ops_data[soff] = new_val
-                        sub_values[i] = new_val
-                        sub_count += 1
-            if sub_count: results.append(f"{sub_count} sub-slots x{mult}")
-
-        if self._spawn_data and self._spawn_schema:
+        if hasattr(self, '_spawn_dmm') and self._spawn_dmm:
             try:
-                from terrain_spawn_parser import parse_all_from_bytes
-                entries, _, _ = parse_all_from_bytes(bytes(self._spawn_data), self._spawn_schema)
+                def _u32f(v):
+                    import ctypes as _ct
+                    return _ct.c_float.from_buffer_copy(_ct.c_uint32(v & 0xFFFFFFFF)).value
+                def _f32u(f):
+                    import ctypes as _ct
+                    return _ct.c_uint32.from_buffer_copy(_ct.c_float(f)).value
 
-                limit_c = mps_c = dup_c = safety_c = dist_c = 0
-                for e in entries:
-                    if not e.get('parse_complete'): continue
-                    for t in e.get('targets', []):
-                        sl_off = t.get('spawn_limit_offset', -1)
-                        if sl_off > 0:
-                            raw = struct.unpack_from('<I', self._spawn_data, sl_off)[0]
-                            if raw == 1:
-                                struct.pack_into('<I', self._spawn_data, sl_off, 0)
-                                limit_c += 1
-
-                            mps_off = sl_off + 4
-                            raw2 = struct.unpack_from('<I', self._spawn_data, mps_off)[0]
-                            if raw2 == 1:
-                                struct.pack_into('<I', self._spawn_data, mps_off, 0)
-                                mps_c += 1
-
-                            dist_off = sl_off + 16
-                            dist_f = struct.unpack_from('<f', self._spawn_data, dist_off)[0]
-                            if 10.0 < dist_f < 10000.0:
-                                struct.pack_into('<f', self._spawn_data, dist_off, min(dist_f * 2, 2000.0))
-                                dist_c += 1
-
-                            safe_off = sl_off + 20
-                            safe_f = struct.unpack_from('<f', self._spawn_data, safe_off)[0]
-                            if safe_f > 20.0:
-                                struct.pack_into('<f', self._spawn_data, safe_off, safe_f / 2)
-                                safety_c += 1
-
-                        for p in t.get('parties', []):
-                            rate_off = p.get('spawn_rate_offset', -1)
-                            if rate_off > 0:
-                                dup_off = rate_off + 24
-                                if dup_off < len(self._spawn_data) and self._spawn_data[dup_off] == 0:
-                                    self._spawn_data[dup_off] = 1
-                                    dup_c += 1
+                limit_c = mps_c = dist_c = safety_c = 0
+                for region in self._spawn_dmm:
+                    for se in region.get('spawn_list', []):
+                        if se.get('raw_a', 0) == 1:
+                            se['raw_a'] = 0
+                            limit_c += 1
+                        if se.get('raw_b', 0) == 1:
+                            se['raw_b'] = 0
+                            mps_c += 1
+                        dist_f = _u32f(se.get('raw_e', 0))
+                        if 10.0 < dist_f < 10000.0:
+                            se['raw_e'] = _f32u(min(dist_f * 2, 2000.0))
+                            dist_c += 1
+                        safe_f = _u32f(se.get('raw_f', 0))
+                        if safe_f > 20.0:
+                            se['raw_f'] = _f32u(safe_f / 2)
+                            safety_c += 1
 
                 if limit_c: results.append(f"{limit_c} spawn caps removed")
                 if mps_c: results.append(f"{mps_c} spawn spacing loosened")
                 if dist_c: results.append(f"{dist_c} spawn distance x2")
                 if safety_c: results.append(f"{safety_c} safety dist halved")
-                if dup_c: results.append(f"{dup_c} duplicates enabled")
             except Exception as _te:
                 log.warning(tr("Terrain spawn modification failed: %s"), _te)
                 log.exception("Unhandled exception")
@@ -2631,69 +2416,51 @@ class SpawnTab(QWidget):
 
         try:
             import crimson_rs
+            import dmm_parser as _dmp_life
+            import copy as _copy_life
             dir_path = "gamedata/binary__/client/bin"
 
-            life_body = crimson_rs.extract_file(
-                game_path, "0008", dir_path, "spawningpoolautospawninfo.pabgb")
-            life_gh = crimson_rs.extract_file(
-                game_path, "0008", dir_path, "spawningpoolautospawninfo.pabgh")
+            life_body = bytes(crimson_rs.extract_file(
+                game_path, "0008", dir_path, "spawningpoolautospawninfo.pabgb"))
+            life_gh = bytes(crimson_rs.extract_file(
+                game_path, "0008", dir_path, "spawningpoolautospawninfo.pabgh"))
 
+            self._spawn_life_dmm = _dmp_life.parse_table(
+                'spawning_pool_auto_spawn_info', life_body, life_gh)
+            self._spawn_life_dmm_vanilla = _copy_life.deepcopy(self._spawn_life_dmm)
             self._spawn_life_data = bytearray(life_body)
-            self._spawn_life_original = bytes(life_body)
-            self._spawn_life_schema = bytes(life_gh)
+            self._spawn_life_original = life_body
+            self._spawn_life_schema = life_gh
 
-            from terrain_spawn_parser import parse_spawningpool_all
-            entries, failures = parse_spawningpool_all(
-                bytes(self._spawn_life_data), self._spawn_life_schema)
+            log.info("Loaded %d spawning pool entries via dmm_parser", len(self._spawn_life_dmm))
 
-            parsed = sum(1 for e in entries if e.get('parse_complete'))
-            log.info("Parsed %d/%d spawning pool entries (%d failures)",
-                     parsed, len(entries), failures)
+            def _u32f(v):
+                import ctypes as _ct
+                return _ct.c_float.from_buffer_copy(_ct.c_uint32(v & 0xFFFFFFFF)).value
+            def _f32u(f):
+                import ctypes as _ct
+                return _ct.c_uint32.from_buffer_copy(_ct.c_float(f)).value
 
-            limit_c = mps_c = dup_c = safety_c = dist_c = 0
-            for e in entries:
-                if not e.get('parse_complete'):
-                    continue
-                for t in e.get('targets', []):
-                    sl_off = t.get('spawn_limit_offset', -1)
-                    if sl_off > 0:
-                        raw = struct.unpack_from('<I', self._spawn_life_data, sl_off)[0]
-                        if raw == 1:
-                            struct.pack_into('<I', self._spawn_life_data, sl_off, 0)
-                            limit_c += 1
+            limit_c = mps_c = safety_c = dist_c = 0
+            for pool in self._spawn_life_dmm:
+                for se in pool.get('spawn_list', []):
+                    if se.get('raw_a', 0) == 1:
+                        se['raw_a'] = 0
+                        limit_c += 1
+                    if se.get('raw_b', 0) == 1:
+                        se['raw_b'] = 0
+                        mps_c += 1
+                    dist_f = _u32f(se.get('raw_e', 0))
+                    if 10.0 < dist_f < 10000.0:
+                        se['raw_e'] = _f32u(min(dist_f * 2, 2000.0))
+                        dist_c += 1
+                    safe_f = _u32f(se.get('raw_f', 0))
+                    if safe_f > 5.0:
+                        se['raw_f'] = _f32u(safe_f / 2)
+                        safety_c += 1
 
-                        mps_off = sl_off + 4
-                        raw2 = struct.unpack_from('<I', self._spawn_life_data, mps_off)[0]
-                        if raw2 == 1:
-                            struct.pack_into('<I', self._spawn_life_data, mps_off, 0)
-                            mps_c += 1
-
-                        dist_off = sl_off + 16
-                        if dist_off + 4 <= len(self._spawn_life_data):
-                            dist_f = struct.unpack_from('<f', self._spawn_life_data, dist_off)[0]
-                            if 10.0 < dist_f < 10000.0:
-                                struct.pack_into('<f', self._spawn_life_data, dist_off,
-                                                 min(dist_f * 2, 2000.0))
-                                dist_c += 1
-
-                        safe_off = sl_off + 20
-                        if safe_off + 4 <= len(self._spawn_life_data):
-                            safe_f = struct.unpack_from('<f', self._spawn_life_data, safe_off)[0]
-                            if safe_f > 5.0:
-                                struct.pack_into('<f', self._spawn_life_data, safe_off, safe_f / 2)
-                                safety_c += 1
-
-                    for p in t.get('parties', []):
-                        rate_off = p.get('spawn_rate_offset', -1)
-                        if rate_off > 0:
-                            dup_off = rate_off + 24
-                            if dup_off < len(self._spawn_life_data) and self._spawn_life_data[dup_off] == 0:
-                                self._spawn_life_data[dup_off] = 1
-                                dup_c += 1
-
-            entries2, fails2 = parse_spawningpool_all(
-                bytes(self._spawn_life_data), self._spawn_life_schema)
-            parsed2 = sum(1 for e in entries2 if e.get('parse_complete'))
+            self._spawn_life_data = bytearray(_dmp_life.serialize_table(
+                'spawning_pool_auto_spawn_info', self._spawn_life_dmm))
 
             self._spawn_modified = True
             results = []
@@ -2701,17 +2468,15 @@ class SpawnTab(QWidget):
             if mps_c: results.append(f"{mps_c} spacing loosened")
             if dist_c: results.append(f"{dist_c} distances x2")
             if safety_c: results.append(f"{safety_c} safety halved")
-            if dup_c: results.append(f"{dup_c} duplicates enabled")
 
             summary = ", ".join(results) if results else "no changes"
             self._spawn_status.setText(
-                f"Ambient life: {parsed2}/{len(entries2)} pools modified ({summary})")
+                f"Ambient life: {len(self._spawn_life_dmm)} pools modified ({summary})")
 
             QMessageBox.information(self, tr("Ambient Life Increased"),
-                f"Modified {parsed} spawning pools (fireflies, birds, bats, insects, etc.):\n\n"
+                f"Modified {len(self._spawn_life_dmm)} spawning pools:\n\n"
                 f"  {chr(10).join(results)}\n\n"
-                f"Verification: {parsed2}/{len(entries2)} still parse OK.\n"
-                "")
+                f"Serialized via dmm_parser — update-proof.")
 
         except Exception as e:
             log.exception("Unhandled exception")
@@ -2719,17 +2484,28 @@ class SpawnTab(QWidget):
             QMessageBox.critical(self, tr("Error"), f"Failed to load ambient life data:\n{e}")
 
     def _spawn_multiply_rates(self):
-        if not self._spawn_data or not self._spawn_schema:
+        if not hasattr(self, '_spawn_dmm') or not self._spawn_dmm:
             QMessageBox.information(self, tr("SpawnEdit"), tr("Load spawn data first."))
             return
 
         mult = self._spawn_multiplier.value()
         try:
-            from terrain_spawn_parser import multiply_spawn_rates
-            count = multiply_spawn_rates(self._spawn_data, self._spawn_schema, mult)
+            import ctypes as _ct_mr
+            count = 0
+            for region in self._spawn_dmm:
+                for se in region.get('spawn_list', []):
+                    for sp in se.get('spline_list', []):
+                        rate_u32 = sp.get('raw_g', 0)
+                        current = _ct_mr.c_float.from_buffer_copy(
+                            _ct_mr.c_uint32(rate_u32 & 0xFFFFFFFF)).value
+                        base = current if current > 0.001 else 1.0
+                        new_val = min(base * mult, 20.0)
+                        sp['raw_g'] = _ct_mr.c_uint32.from_buffer_copy(
+                            _ct_mr.c_float(new_val)).value
+                        count += 1
             self._spawn_modified = True
             self._spawn_update_changes()
-            self._spawn_status.setText(f"Multiplied {count} verified spawn rates by {mult}x (parse-tree safe)")
+            self._spawn_status.setText(f"Multiplied {count} spawn rates by {mult}x via dmm_parser")
         except Exception as e:
             log.exception("Unhandled exception")
             QMessageBox.critical(self, tr("SpawnEdit"), f"Failed to multiply rates: {e}")
@@ -2741,12 +2517,14 @@ class SpawnTab(QWidget):
 
         count = 0
         for el in self._spawn_elements:
-            if el.get('source') != 'terrain' or el['timer_offset'] < 0:
+            if el.get('source') != 'terrain':
                 continue
             old = el['timer_ms']
             new_val = max(old // 2, 50)
             if new_val != old:
-                struct.pack_into('<I', self._spawn_data, el['timer_offset'], new_val)
+                spline = el.get('spline_ref')
+                if spline is not None:
+                    spline['raw_qword'] = new_val
                 el['timer_ms'] = new_val
                 count += 1
 
@@ -2756,35 +2534,32 @@ class SpawnTab(QWidget):
         self._spawn_status.setText(f"Halved {count} respawn timers")
 
     def _spawn_reset(self):
-        if not self._spawn_original:
-            return
-        self._spawn_data = bytearray(self._spawn_original)
+        import copy as _copy_reset
+        if hasattr(self, '_spawn_dmm_vanilla') and self._spawn_dmm_vanilla:
+            self._spawn_dmm = _copy_reset.deepcopy(self._spawn_dmm_vanilla)
+        if self._spawn_original:
+            self._spawn_data = bytearray(self._spawn_original)
         if hasattr(self, '_spawn_node_original') and self._spawn_node_original:
             self._spawn_node_data = bytearray(self._spawn_node_original)
         if hasattr(self, '_spawn_fnode_ops_original') and self._spawn_fnode_ops_original:
             self._spawn_fnode_ops_data = bytearray(self._spawn_fnode_ops_original)
+
         for el in self._spawn_elements:
             src = el.get('source', '')
-            if src == 'terrain' and el['count_offset'] >= 0:
-                el['spawn_count'] = struct.unpack_from('<I', self._spawn_data, el['count_offset'])[0]
-                el['timer_ms'] = struct.unpack_from('<I', self._spawn_data, el['timer_offset'])[0]
-            elif src == 'fnode' and el['count_offset'] >= 0 and hasattr(self, '_spawn_node_data'):
-                el['spawn_count'] = round(struct.unpack_from('<f', self._spawn_node_data, el['count_offset'])[0], 2)
-            elif src == 'fnode_ops' and el['count_offset'] >= 0 and hasattr(self, '_spawn_fnode_ops_data'):
-                el['spawn_count'] = self._spawn_fnode_ops_data[el['count_offset']]
-                min_off = el.get('min_op_offset', -1)
-                if min_off >= 0:
-                    el['min_op'] = self._spawn_fnode_ops_data[min_off]
-                wc_off = el.get('worker_count_offset', -1)
-                if wc_off >= 0:
-                    el['worker_count'] = self._spawn_fnode_ops_data[wc_off]
-                for se in el.get('sub_elements', []):
-                    if se.get('count_offset', -1) >= 0:
-                        se['count'] = self._spawn_fnode_ops_data[se['count_offset']]
-                    if se.get('time_offset', -1) >= 0:
-                        se['time'] = struct.unpack_from('<I', self._spawn_fnode_ops_data, se['time_offset'])[0]
-            elif src == 'fnode_info' and el['count_offset'] >= 0 and hasattr(self, '_spawn_fnode_ops_data'):
-                el['spawn_count'] = round(struct.unpack_from('<f', self._spawn_fnode_ops_data, el['count_offset'])[0], 2)
+            if src == 'terrain':
+                el['spawn_count'] = el.get('vanilla_count', el['spawn_count'])
+                el['timer_ms'] = el.get('vanilla_timer', el['timer_ms'])
+                inner = el.get('inner_ref')
+                if inner is not None:
+                    inner['flag_a'] = el['spawn_count']
+                spline = el.get('spline_ref')
+                if spline is not None:
+                    spline['raw_qword'] = el['timer_ms']
+            elif src == 'fnode_ops':
+                el['spawn_count'] = el.get('vanilla_count', el['spawn_count'])
+                rde = el.get('rde_ref')
+                if rde is not None:
+                    rde['flag'] = el['spawn_count']
         self._spawn_modified = False
         self._spawn_changes_label.setText("")
         self._spawn_filter()
@@ -2812,12 +2587,11 @@ class SpawnTab(QWidget):
             return
         out_path = os.path.join(save_dir, folder_name)
 
-        self._spawn_status.setText(tr("Packing with pack_mod..."))
+        self._spawn_status.setText(tr("Packing overlay..."))
         QApplication.processEvents()
 
         try:
             import crimson_rs
-            import crimson_rs.pack_mod
             import tempfile
             import shutil
 
@@ -2827,43 +2601,63 @@ class SpawnTab(QWidget):
                 shutil.rmtree(out_path)
             os.makedirs(out_path, exist_ok=True)
 
+            INTERNAL_DIR = "gamedata/binary__/client/bin"
+            mod_group = f"{self._spawn_overlay_spin.value():04d}"
+
+            import dmm_parser as _dmp_exp
+            if hasattr(self, '_spawn_dmm') and self._spawn_dmm:
+                terrain_exp_bytes = _dmp_exp.serialize_table(
+                    'terrain_region_auto_spawn_info', self._spawn_dmm)
+            else:
+                terrain_exp_bytes = bytes(self._spawn_data)
+
+            spawn_files = [
+                ("terrainregionautospawninfo", terrain_exp_bytes, self._spawn_schema),
+            ]
+            if hasattr(self, '_spawn_node_data') and self._spawn_node_data:
+                spawn_files.append(("factionnodespawninfo", self._spawn_node_data,
+                    getattr(self, '_spawn_node_schema', None)))
+            if hasattr(self, '_spawn_fnode_dmm') and self._spawn_fnode_dmm:
+                import dmm_parser as _dmp_fn
+                fnode_bytes = _dmp_fn.serialize_table('faction_node_info', self._spawn_fnode_dmm)
+                spawn_files.append(("factionnode", fnode_bytes,
+                    getattr(self, '_spawn_fnode_ops_schema', None)))
+            elif hasattr(self, '_spawn_fnode_ops_data') and self._spawn_fnode_ops_data:
+                spawn_files.append(("factionnode", self._spawn_fnode_ops_data,
+                    getattr(self, '_spawn_fnode_ops_schema', None)))
+            if hasattr(self, '_spawn_life_data') and self._spawn_life_data:
+                spawn_files.append(("spawningpoolautospawninfo", self._spawn_life_data,
+                    getattr(self, '_spawn_life_schema', None)))
+
             with tempfile.TemporaryDirectory() as tmp_dir:
-                mod_dir = os.path.join(tmp_dir, "gamedata", "binary__", "client", "bin")
-                os.makedirs(mod_dir, exist_ok=True)
-                with open(os.path.join(mod_dir, "terrainregionautospawninfo.pabgb"), "wb") as f:
-                    f.write(self._spawn_data)
-                if hasattr(self, '_spawn_node_data') and self._spawn_node_data:
-                    with open(os.path.join(mod_dir, "factionnodespawninfo.pabgb"), "wb") as f:
-                        f.write(self._spawn_node_data)
-                if hasattr(self, '_spawn_fnode_ops_data') and self._spawn_fnode_ops_data:
-                    with open(os.path.join(mod_dir, "factionnode.pabgb"), "wb") as f:
-                        f.write(self._spawn_fnode_ops_data)
-                if hasattr(self, '_spawn_life_data') and self._spawn_life_data:
-                    with open(os.path.join(mod_dir, "spawningpoolautospawninfo.pabgb"), "wb") as f:
-                        f.write(self._spawn_life_data)
+                group_dir = os.path.join(tmp_dir, mod_group)
+                builder = crimson_rs.PackGroupBuilder(
+                    group_dir, crimson_rs.Compression.NONE,
+                    crimson_rs.Crypto.NONE)
 
-                pack_out = os.path.join(tmp_dir, "output")
-                os.makedirs(pack_out, exist_ok=True)
+                for stem, data, schema in spawn_files:
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgb", bytes(data))
+                    pabgh = schema
+                    if not pabgh:
+                        pabgh = bytes(crimson_rs.extract_file(
+                            game_path, "0008", INTERNAL_DIR, f"{stem}.pabgh"))
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgh", bytes(pabgh))
 
-                mod_group = f"{self._spawn_overlay_spin.value():04d}"
-                crimson_rs.pack_mod.pack_mod(
-                    game_dir=game_path,
-                    mod_folder=tmp_dir,
-                    output_dir=pack_out,
-                    group_name=mod_group,
-                )
+                pamt_bytes = bytes(builder.finish())
+                pamt_checksum = crimson_rs.parse_pamt_bytes(pamt_bytes)["checksum"]
 
                 paz_dst = os.path.join(out_path, mod_group)
                 os.makedirs(paz_dst, exist_ok=True)
-                shutil.copy2(os.path.join(pack_out, mod_group, "0.paz"),
-                             os.path.join(paz_dst, "0.paz"))
-                shutil.copy2(os.path.join(pack_out, mod_group, "0.pamt"),
-                             os.path.join(paz_dst, "0.pamt"))
+                for fn in os.listdir(group_dir):
+                    shutil.copy2(os.path.join(group_dir, fn),
+                                 os.path.join(paz_dst, fn))
 
                 meta_dst = os.path.join(out_path, "meta")
                 os.makedirs(meta_dst, exist_ok=True)
-                shutil.copy2(os.path.join(pack_out, "meta", "0.papgt"),
-                             os.path.join(meta_dst, "0.papgt"))
+                papgt = {"entries": []}
+                papgt = crimson_rs.add_papgt_entry(
+                    papgt, mod_group, pamt_checksum, 0, 16383)
+                crimson_rs.write_papgt_file(papgt, os.path.join(meta_dst, "0.papgt"))
 
             modinfo = {
                 "id": name.lower().replace(" ", "_"),
@@ -2895,8 +2689,6 @@ class SpawnTab(QWidget):
     def _spawn_export_field_json_v3(self) -> None:
         """Export SpawnEdit modifications as Format 3.1 multi-target field JSON."""
         try:
-            import struct as _st
-
             if not self._spawn_data or not self._spawn_original:
                 QMessageBox.information(self, tr("Export Field JSON v3"),
                     tr("No spawn data loaded. Extract spawn data first."))
@@ -2926,37 +2718,35 @@ class SpawnTab(QWidget):
 
             targets = []
 
-            # terrainregionautospawninfo — annotate with region/char names where known
-            ter_intents = _diff_table(self._spawn_data, self._spawn_original, 'terrain')
-            # Enrich with names from element map
-            off_map = {}
-            for elem in getattr(self, '_spawn_elements', []):
-                region = elem.get('region_name', f"Region_{elem.get('region_key','?')}")
-                char_key = elem.get('char_key', 0)
-                rkey = elem.get('region_key', 0)
-                label = f"{region}_char{char_key}"
-                for fname, okey in [('spawn_count','count_offset'),
-                                     ('timer_ms','timer_offset'),
-                                     ('max_operator_count','max_operator_offset')]:
-                    off = elem.get(okey, -1)
-                    if off >= 0:
-                        off_map[off] = (label, fname, rkey)
-            for intent in ter_intents:
-                off = intent['_offset']
-                if off in off_map:
-                    label, fname, rkey = off_map[off]
-                    intent['entry'] = label
-                    intent['field'] = fname
-                    intent['key'] = rkey
-            if ter_intents:
-                targets.append({'file': 'terrainregionautospawninfo.pabgb',
-                                'intents': ter_intents})
+            import dmm_parser as _dmp_ej
+            # terrainregionautospawninfo — serialize current vs vanilla
+            if hasattr(self, '_spawn_dmm') and self._spawn_dmm and hasattr(self, '_spawn_dmm_vanilla'):
+                cur_ter = _dmp_ej.serialize_table('terrain_region_auto_spawn_info', self._spawn_dmm)
+                van_ter = _dmp_ej.serialize_table('terrain_region_auto_spawn_info', self._spawn_dmm_vanilla)
+                ter_intents = _diff_table(cur_ter, van_ter, 'terrain')
+                if ter_intents:
+                    targets.append({'file': 'terrainregionautospawninfo.pabgb',
+                                    'intents': ter_intents})
 
-            # other tables
+            # factionnode — serialize current vs vanilla
+            if hasattr(self, '_spawn_fnode_dmm') and self._spawn_fnode_dmm and hasattr(self, '_spawn_fnode_dmm_vanilla'):
+                cur_fn = _dmp_ej.serialize_table('faction_node_info', self._spawn_fnode_dmm)
+                van_fn = _dmp_ej.serialize_table('faction_node_info', self._spawn_fnode_dmm_vanilla)
+                fn_intents = _diff_table(cur_fn, van_fn, 'factionnode')
+                if fn_intents:
+                    targets.append({'file': 'factionnode.pabgb', 'intents': fn_intents})
+
+            # spawningpool — serialize if modified
+            if hasattr(self, '_spawn_life_dmm') and self._spawn_life_dmm and hasattr(self, '_spawn_life_dmm_vanilla'):
+                cur_lf = _dmp_ej.serialize_table('spawning_pool_auto_spawn_info', self._spawn_life_dmm)
+                van_lf = _dmp_ej.serialize_table('spawning_pool_auto_spawn_info', self._spawn_life_dmm_vanilla)
+                lf_intents = _diff_table(cur_lf, van_lf, 'spawningpool')
+                if lf_intents:
+                    targets.append({'file': 'spawningpoolautospawninfo.pabgb', 'intents': lf_intents})
+
+            # factionnodespawninfo — byte buffer fallback
             for cur_attr, van_attr, fname in [
-                ('_spawn_life_data',      '_spawn_life_original',      'spawningpoolautospawninfo.pabgb'),
-                ('_spawn_node_data',      '_spawn_node_original',      'factionnodespawninfo.pabgb'),
-                ('_spawn_fnode_ops_data', '_spawn_fnode_ops_original', 'faction_node_info.pabgb'),
+                ('_spawn_node_data', '_spawn_node_original', 'factionnodespawninfo.pabgb'),
             ]:
                 cur = getattr(self, cur_attr, None)
                 van = getattr(self, van_attr, None)
@@ -3033,41 +2823,60 @@ class SpawnTab(QWidget):
         if reply != QMessageBox.Yes:
             return
 
-        self._spawn_status.setText(tr("Packing with pack_mod..."))
+        self._spawn_status.setText(tr("Packing overlay..."))
         QApplication.processEvents()
 
         try:
-            import crimson_rs.pack_mod
+            import crimson_rs
             import shutil
             import tempfile
             from pathlib import Path
 
             gp = Path(game_path)
+            INTERNAL_DIR = "gamedata/binary__/client/bin"
+
+            # Serialize terrain from dmm_parser if available
+            import dmm_parser as _dmp_apply
+            if hasattr(self, '_spawn_dmm') and self._spawn_dmm:
+                terrain_bytes = _dmp_apply.serialize_table(
+                    'terrain_region_auto_spawn_info', self._spawn_dmm)
+            else:
+                terrain_bytes = bytes(self._spawn_data)
+
+            spawn_files = [
+                ("terrainregionautospawninfo", terrain_bytes, self._spawn_schema),
+            ]
+            if hasattr(self, '_spawn_node_data') and self._spawn_node_data:
+                spawn_files.append(("factionnodespawninfo", self._spawn_node_data,
+                    getattr(self, '_spawn_node_schema', None)))
+            if hasattr(self, '_spawn_fnode_dmm') and self._spawn_fnode_dmm:
+                import dmm_parser as _dmp_fn
+                fnode_bytes = _dmp_fn.serialize_table('faction_node_info', self._spawn_fnode_dmm)
+                spawn_files.append(("factionnode", fnode_bytes,
+                    getattr(self, '_spawn_fnode_ops_schema', None)))
+            elif hasattr(self, '_spawn_fnode_ops_data') and self._spawn_fnode_ops_data:
+                spawn_files.append(("factionnode", self._spawn_fnode_ops_data,
+                    getattr(self, '_spawn_fnode_ops_schema', None)))
+            if hasattr(self, '_spawn_life_data') and self._spawn_life_data:
+                spawn_files.append(("spawningpoolautospawninfo", self._spawn_life_data,
+                    getattr(self, '_spawn_life_schema', None)))
 
             with tempfile.TemporaryDirectory() as tmp_dir:
-                mod_dir = os.path.join(tmp_dir, "gamedata", "binary__", "client", "bin")
-                os.makedirs(mod_dir, exist_ok=True)
-                with open(os.path.join(mod_dir, "terrainregionautospawninfo.pabgb"), "wb") as f:
-                    f.write(self._spawn_data)
-                if hasattr(self, '_spawn_node_data') and self._spawn_node_data:
-                    with open(os.path.join(mod_dir, "factionnodespawninfo.pabgb"), "wb") as f:
-                        f.write(self._spawn_node_data)
-                if hasattr(self, '_spawn_fnode_ops_data') and self._spawn_fnode_ops_data:
-                    with open(os.path.join(mod_dir, "factionnode.pabgb"), "wb") as f:
-                        f.write(self._spawn_fnode_ops_data)
-                if hasattr(self, '_spawn_life_data') and self._spawn_life_data:
-                    with open(os.path.join(mod_dir, "spawningpoolautospawninfo.pabgb"), "wb") as f:
-                        f.write(self._spawn_life_data)
+                group_dir = os.path.join(tmp_dir, mod_group)
+                builder = crimson_rs.PackGroupBuilder(
+                    group_dir, crimson_rs.Compression.NONE,
+                    crimson_rs.Crypto.NONE)
 
-                pack_out = os.path.join(tmp_dir, "output")
-                os.makedirs(pack_out, exist_ok=True)
+                for stem, data, schema in spawn_files:
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgb", bytes(data))
+                    pabgh = schema
+                    if not pabgh:
+                        pabgh = bytes(crimson_rs.extract_file(
+                            game_path, "0008", INTERNAL_DIR, f"{stem}.pabgh"))
+                    builder.add_file(INTERNAL_DIR, f"{stem}.pabgh", bytes(pabgh))
 
-                crimson_rs.pack_mod.pack_mod(
-                    game_dir=game_path,
-                    mod_folder=tmp_dir,
-                    output_dir=pack_out,
-                    group_name=mod_group,
-                )
+                pamt_bytes = bytes(builder.finish())
+                pamt_checksum = crimson_rs.parse_pamt_bytes(pamt_bytes)["checksum"]
 
                 papgt_path = gp / "meta" / "0.papgt"
                 backup_path = papgt_path.with_suffix(".papgt.spawn_bak")
@@ -3076,12 +2885,15 @@ class SpawnTab(QWidget):
 
                 dest = gp / mod_group
                 dest.mkdir(exist_ok=True)
-                shutil.copyfile(
-                    os.path.join(pack_out, mod_group, "0.paz"), dest / "0.paz")
-                shutil.copyfile(
-                    os.path.join(pack_out, mod_group, "0.pamt"), dest / "0.pamt")
-                shutil.copyfile(
-                    os.path.join(pack_out, "meta", "0.papgt"), papgt_path)
+                for fn in os.listdir(group_dir):
+                    shutil.copy2(os.path.join(group_dir, fn), str(dest / fn))
+
+                papgt = crimson_rs.parse_papgt_file(str(papgt_path))
+                papgt["entries"] = [e for e in papgt["entries"]
+                                    if e.get("group_name") != mod_group]
+                papgt = crimson_rs.add_papgt_entry(
+                    papgt, mod_group, pamt_checksum, 0, 16383)
+                crimson_rs.write_papgt_file(papgt, str(papgt_path))
 
             self._spawn_status.setText(f"Applied to {mod_group}/")
             QMessageBox.information(self, tr("Applied"),
@@ -3541,18 +3353,26 @@ class DropsetTab(QWidget):
             body_data = crimson_rs.extract_file(game_path, "0008", dir_path, "dropsetinfo.pabgb")
             header_data = crimson_rs.extract_file(game_path, "0008", dir_path, "dropsetinfo.pabgh")
 
+            import dmm_parser as _dmp_ds
+            import copy as _copy_ds
+            hdr = bytes(header_data)
+            bod = bytes(body_data)
+            self._dropset_dmm = _dmp_ds.parse_table('drop_set_info', bod, hdr)
+            self._dropset_dmm_vanilla = _copy_ds.deepcopy(self._dropset_dmm)
+            self._dropset_gh = hdr
+
             from dropset_editor import DropsetEditor
             editor = DropsetEditor()
-            editor.header_bytes = bytes(header_data)
+            editor.header_bytes = hdr
             editor.body_bytes = bytearray(body_data)
-
-            import struct
-            editor.record_count = struct.unpack_from("<H", editor.header_bytes, 0)[0]
+            c16 = int.from_bytes(hdr[0:2], 'little')
+            editor.record_count = c16
             editor.records = []
-            for i in range(editor.record_count):
-                off = 2 + i * 8
-                key, offset = struct.unpack_from("<II", editor.header_bytes, off)
-                editor.records.append((key, offset))
+            for i in range(c16):
+                p = 2 + i * 8
+                k = int.from_bytes(hdr[p:p+4], 'little')
+                o = int.from_bytes(hdr[p+4:p+8], 'little')
+                editor.records.append((k, o))
 
             editor.load_item_names()
 
@@ -4091,13 +3911,14 @@ class DropsetTab(QWidget):
             orig = DropsetEditor()
             orig.header_bytes = self._dropset_original_header
             orig.body_bytes = bytearray(self._dropset_original_body)
-            import struct
-            orig.record_count = struct.unpack_from("<H", orig.header_bytes, 0)[0]
+            _hdr = orig.header_bytes
+            _c = int.from_bytes(_hdr[0:2], 'little')
+            orig.record_count = _c
             orig.records = []
-            for i in range(orig.record_count):
-                off = 2 + i * 8
-                key, offset = struct.unpack_from("<II", orig.header_bytes, off)
-                orig.records.append((key, offset))
+            for i in range(_c):
+                _p = 2 + i * 8
+                orig.records.append((int.from_bytes(_hdr[_p:_p+4], 'little'),
+                                     int.from_bytes(_hdr[_p+4:_p+8], 'little')))
 
             for key, _ in self._dropset_editor.records:
                 ds_new = self._dropset_editor.parse_dropset(key)
@@ -4228,36 +4049,27 @@ class DropsetTab(QWidget):
         if reply != QMessageBox.Yes:
             return
 
-        self._dropset_status.setText(tr("Packing with pack_mod..."))
+        self._dropset_status.setText(tr("Packing overlay..."))
         QApplication.processEvents()
 
         try:
-            import crimson_rs.pack_mod
-            from crimson_rs import Compression
+            import crimson_rs
             import shutil
             import tempfile
             from pathlib import Path
 
             gp = Path(game_path)
+            INTERNAL_DIR = "gamedata/binary__/client/bin"
 
             with tempfile.TemporaryDirectory() as tmp_dir:
-                mod_dir = os.path.join(tmp_dir, "gamedata", "binary__", "client", "bin")
-                os.makedirs(mod_dir, exist_ok=True)
-                with open(os.path.join(mod_dir, "dropsetinfo.pabgb"), "wb") as f:
-                    f.write(body_data)
-                with open(os.path.join(mod_dir, "dropsetinfo.pabgh"), "wb") as f:
-                    f.write(header_data)
-
-                out_dir = os.path.join(tmp_dir, "output")
-                os.makedirs(out_dir, exist_ok=True)
-
-                crimson_rs.pack_mod.pack_mod(
-                    game_dir=game_path,
-                    mod_folder=tmp_dir,
-                    output_dir=out_dir,
-                    group_name=group_name,
-                    compression=Compression.NONE,
-                )
+                grp_dir = os.path.join(tmp_dir, group_name)
+                builder = crimson_rs.PackGroupBuilder(
+                    grp_dir, crimson_rs.Compression.NONE,
+                    crimson_rs.Crypto.NONE)
+                builder.add_file(INTERNAL_DIR, "dropsetinfo.pabgb", body_data)
+                builder.add_file(INTERNAL_DIR, "dropsetinfo.pabgh", header_data)
+                pamt_bytes = bytes(builder.finish())
+                pamt_checksum = crimson_rs.parse_pamt_bytes(pamt_bytes)["checksum"]
 
                 papgt_path = gp / "meta" / "0.papgt"
                 backup_path = papgt_path.with_suffix(".papgt.dropset_bak")
@@ -4266,12 +4078,15 @@ class DropsetTab(QWidget):
 
                 dest = gp / group_name
                 dest.mkdir(exist_ok=True)
-                shutil.copyfile(
-                    os.path.join(out_dir, group_name, "0.paz"), dest / "0.paz")
-                shutil.copyfile(
-                    os.path.join(out_dir, group_name, "0.pamt"), dest / "0.pamt")
-                shutil.copyfile(
-                    os.path.join(out_dir, "meta", "0.papgt"), papgt_path)
+                for fn in os.listdir(grp_dir):
+                    shutil.copy2(os.path.join(grp_dir, fn), str(dest / fn))
+
+                papgt = crimson_rs.parse_papgt_file(str(papgt_path))
+                papgt["entries"] = [e for e in papgt["entries"]
+                                    if e.get("group_name") != group_name]
+                papgt = crimson_rs.add_papgt_entry(
+                    papgt, group_name, pamt_checksum, 0, 16383)
+                crimson_rs.write_papgt_file(papgt, str(papgt_path))
 
             paz_size = (dest / "0.paz").stat().st_size
             try:
@@ -4426,15 +4241,17 @@ class DropsetTab(QWidget):
             return
 
         try:
-            import struct
             from dropset_editor import DropsetEditor
 
             orig = DropsetEditor()
             orig.header_bytes = self._dropset_original_header
             orig.body_bytes = bytearray(self._dropset_original_body)
-            orig.record_count = struct.unpack_from("<H", orig.header_bytes, 0)[0]
-            orig.records = [(struct.unpack_from("<II", orig.header_bytes, 2+i*8))
-                            for i in range(orig.record_count)]
+            _hdr2 = orig.header_bytes
+            _c2 = int.from_bytes(_hdr2[0:2], 'little')
+            orig.record_count = _c2
+            orig.records = [(int.from_bytes(_hdr2[2+i*8:6+i*8], 'little'),
+                             int.from_bytes(_hdr2[6+i*8:10+i*8], 'little'))
+                            for i in range(_c2)]
 
             config = {
                 "format": "crimson_dropset_config",
@@ -5059,14 +4876,14 @@ class PabgbBrowserTab(QWidget):
                 self._pabgb_status.setText(tr("File too small"))
                 return
 
-            record_count = struct.unpack_from('<I', data, 0)[0]
+            record_count = int.from_bytes(data[0:4], 'little')
 
             offset = 4
             while offset < len(data) - 8:
                 if offset + 8 > len(data):
                     break
-                key = struct.unpack_from('<I', data, offset)[0]
-                name_len = struct.unpack_from('<I', data, offset + 4)[0]
+                key = int.from_bytes(data[offset:offset+4], 'little')
+                name_len = int.from_bytes(data[offset+4:offset+8], 'little')
 
                 if name_len < 1 or name_len > 200:
                     offset += 1


### PR DESCRIPTION
## Summary
- **world.py**: 63 → 0 `struct.pack_into`/`unpack_from` — store editor, terrain spawns, factionnode operators, spawning pool, drop rates, skill cooldowns all via dmm_parser field-level dicts
- **field_edit.py**: 39 → 0 — vehicle altitude, mount duration/cooldown, weapon package hashes, regioninfo flags, Kliff gun fix, presets all via dmm_parser
- **buffs_v319.py**: Fix transmog dialog crash when `category` is `None`
- All `pack_mod()` calls replaced with `PackGroupBuilder(NONE)` + proper PAPGT
- Old Python parsers eliminated: `terrain_spawn_parser`, `factionnode_operator_parser`, `storeinfo_parser`, `store_editor`

## Why
Game updates weekly. Every hardcoded byte offset breaks. dmm_parser (Rust, Potter's 122-table parser) resolves fields by name from the pabgh schema — survives format changes automatically.

## Field mapping (verified via sentinel injection)
| Game concept | dmm_parser field | Table |
|---|---|---|
| Store buy price | `stock_data_list[].raw_a` | `store_info` |
| Spawn count | `spline_list[].inner_list[].flag_a` | `terrain_region_auto_spawn_info` |
| Spawn timer | `spline_list[].raw_qword` | `terrain_region_auto_spawn_info` |
| Spawn rate | `spline_list[].raw_g` | `terrain_region_auto_spawn_info` |
| Camp max operator | `faction_schedule_list[].raw_data_ext.flag` | `faction_node_info` |
| Altitude cap | `max_allowable_height` | `vehicle_info` |
| Mount duration | `call_mercenary_spawn_duration` | `character_info` |
| Weapon upper chart | `appearance_name` | `character_info` |

## Test plan
- [x] All 7 dmm_parser tables round-trip byte-for-byte
- [x] Full app import (all tabs)
- [x] Store: Load → edit limits → display
- [x] Spawn: Load → halve timers → multiply camp max → increase all → restore
- [x] FieldEdit: Load → Enable Mounts → Make Killable
- [x] PyInstaller build succeeds (73MB exe)
- [ ] In-game verification of applied mods

🤖 Generated with [Claude Code](https://claude.com/claude-code)