### PR TITLE
Fix for Windows Build from Source 

### DIFF
--- a/CrimsonGameMods/CrimsonGameMods.spec
+++ b/CrimsonGameMods/CrimsonGameMods.spec
@@ -1,5 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from pathlib import Path
+Path("quest_packs").mkdir(exist_ok=True)
 
 a = Analysis(
     ['main.py'],


### PR DESCRIPTION
The current Windows build from source fails because the quest_packs folder does not exist in the repository. Since Github can't have empty folders, a quick bandaid fix is to just create the directory if it doesn't exist before the PyInstaller script looks for it.

Fixes https://github.com/NattKh/CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS/issues/82