### PR TITLE
Knowledge tab: silent learn no-op, misaligned scan, unlearn buffer overrun

### DIFF
--- a/CrimsonSaveEditor/gui.py
+++ b/CrimsonSaveEditor/gui.py
@@ -13625,6 +13625,31 @@ QCheckBox::indicator {{
         self._tabs.addTab(tab, "Teleport")
 
 
+    def _know_parse_entries(self):
+        """Yield (key, level, level_offset) for every knowledge entry."""
+        result = self._get_parse_result()
+        if not result:
+            return
+        import struct as _st
+        blob = self._save_data.decompressed_blob
+        for obj in result['objects']:
+            if obj.class_name != 'KnowledgeSaveData':
+                continue
+            for f in obj.fields:
+                if f.name != '_list' or not f.list_elements:
+                    continue
+                for elem in f.list_elements:
+                    key = level = level_offset = None
+                    for cf in (elem.child_fields or []):
+                        if cf.name == '_key' and cf.present:
+                            key = _st.unpack_from('<I', blob, cf.start_offset)[0]
+                        elif cf.name == '_level' and cf.present:
+                            level_offset = cf.start_offset
+                            level = _st.unpack_from('<I', blob, cf.start_offset)[0]
+                    if key is not None and level is not None:
+                        yield key, level, level_offset
+            return
+
     def _know_scan(self) -> None:
         if not self._save_data:
             QMessageBox.warning(self, "Knowledge", "Load a save file first.")
@@ -13642,19 +13667,13 @@ QCheckBox::indicator {{
             from save_parser import build_result_from_raw, parse_schema, parse_toc
             import struct as _st
 
-            blob = bytes(self._save_data.decompressed_blob)
-            schema = parse_schema(blob)
-            toc = parse_toc(blob, schema['schema_end'], [t.name for t in schema['types']])
-
+            # The 4-byte-stride pattern walk missed keys at unaligned
+            # offsets and counted level-0 leftovers as learned; the cached
+            # parse tree is exact and carries the level.
             self._know_learned_keys = set()
-            for e in toc['entries']:
-                if e.class_name == 'KnowledgeSaveData':
-                    block = blob[e.data_offset:e.data_offset + e.data_size]
-                    for off in range(0, len(block) - 3, 4):
-                        v = _st.unpack_from('<I', block, off)[0]
-                        if 1000000 <= v <= 1999999:
-                            self._know_learned_keys.add(v)
-                    break
+            for key, level, _off in self._know_parse_entries():
+                if level >= 1:
+                    self._know_learned_keys.add(key)
 
             know_path = os.path.join(
                 getattr(sys, '_MEIPASS', os.path.dirname(__file__)),
@@ -13810,27 +13829,20 @@ QCheckBox::indicator {{
 
         try:
             import struct as _st
-            entry, raw = self._find_parc_block("KnowledgeSaveData")
-            if not entry or not raw:
-                QMessageBox.warning(self, "Knowledge", "KnowledgeSaveData block not found.")
-                return
-
-            target_keys = set(to_unlearn)
-            abs_base = entry.data_offset
             blob = self._save_data.decompressed_blob
+            target_keys = set(to_unlearn)
             patches = []
             unlearned = 0
-
-            for i in range(len(raw) - 14):
-                key = _st.unpack_from("<I", raw, i)[0]
-                level = _st.unpack_from("<I", raw, i + 4)[0]
-                ts = _st.unpack_from("<Q", raw, i + 8)[0]
-                if key in target_keys and 1 <= level <= 5 and ts > 1000000:
-                    abs_off = abs_base + i + 4
-                    old_bytes = bytes(blob[abs_off:abs_off + 4])
+            # Patch the level field through the parse tree - the raw byte
+            # scan misread unaligned records and could overrun the block
+            # tail (it unpacked eight bytes at i+8 while iterating to
+            # len-14).
+            for key, level, level_offset in self._know_parse_entries():
+                if key in target_keys and level >= 1 and level_offset is not None:
+                    old_bytes = bytes(blob[level_offset:level_offset + 4])
                     new_bytes = _st.pack("<I", 0)
-                    blob[abs_off:abs_off + 4] = new_bytes
-                    patches.append((abs_off, old_bytes, new_bytes))
+                    blob[level_offset:level_offset + 4] = new_bytes
+                    patches.append((level_offset, old_bytes, new_bytes))
                     target_keys.discard(key)
                     unlearned += 1
 
@@ -14277,6 +14289,7 @@ QCheckBox::indicator {{
                     f"{msg} | {learned_count}/{len(self._know_all_entries)} learned"
                 )
 
+                self._know_filter()
                 QMessageBox.information(self, "Knowledge Injected",
                     f"{msg}\n\nSave (Ctrl+S) for changes to take effect.")
             else:
@@ -14707,7 +14720,7 @@ QCheckBox::indicator {{
             QMessageBox.warning(self, "Debug", "KnowledgeSaveData block not found in save.")
             return
         matches = []
-        for i in range(len(raw) - 14):
+        for i in range(len(raw) - 15):
             key = struct.unpack_from("<I", raw, i)[0]
             level = struct.unpack_from("<I", raw, i + 4)[0]
             ts = struct.unpack_from("<Q", raw, i + 8)[0]

--- a/CrimsonSaveEditor/gui.py
+++ b/CrimsonSaveEditor/gui.py
@@ -30,7 +30,7 @@ from PySide6.QtWidgets import (
 from models import SaveItem, SaveData, UndoEntry
 from save_crypto import load_save_file, load_raw_stream, write_save_file
 from item_scanner import (
-    scan_items, apply_stack_edit, apply_enchant_edit,
+    scan_items, scan_items_smart, apply_stack_edit, apply_enchant_edit,
     apply_endurance_edit, apply_sharpness_edit, apply_item_swap, apply_item_swap_all,
     enrich_items_with_parc, smart_item_swap,
     apply_itemno_edit, get_max_itemno,
@@ -2413,6 +2413,11 @@ class MainWindow(QMainWindow):
         self.setMinimumSize(800, 500)
 
         self._save_data: Optional[SaveData] = None
+        # One full parse per loaded save, reused by item extraction (and any
+        # future consumer). In-place byte edits keep it valid; replacing the
+        # blob makes the next call re-parse.
+        from parse_reuse import ParsedResultCache
+        self._parse_cache = ParsedResultCache()
         self._items: List[SaveItem] = []
         self._name_db = ItemNameDB()
         self._pack_mgr = PackManager()
@@ -31429,13 +31434,33 @@ QCheckBox::indicator {{
                 f"{len(duplicated_nos)} group(s) — each item now has a unique ID."
             )
 
+    def _get_parse_result(self):
+        """Full parse of the current save, cached until the blob is replaced."""
+        if not self._save_data:
+            return None
+        cached = self._parse_cache.get(self._save_data)
+        if cached is not None:
+            return cached
+        from save_parser import build_result_from_raw
+        result = build_result_from_raw(
+            bytes(self._save_data.decompressed_blob), {'input_kind': 'raw_blob'}
+        )
+        self._parse_cache.store(self._save_data, result)
+        return result
+
     def _scan_and_populate(self) -> None:
         if not self._save_data:
             return
 
         self._quest_entries = []
         self._mission_entries = []
-        self._items = scan_items(self._save_data.decompressed_blob)
+        try:
+            parse_result = self._get_parse_result()
+        except Exception:
+            parse_result = None
+        self._items = scan_items_smart(
+            self._save_data.decompressed_blob, parse_result
+        )
 
         for item in self._items:
             item.name = self._name_db.get_name(item.item_key)

--- a/CrimsonSaveEditor/item_scanner.py
+++ b/CrimsonSaveEditor/item_scanner.py
@@ -438,7 +438,7 @@ _ITEM_FIELD_NAMES = [
 
 def _try_import_parc():
     try:
-        import parc_serializer
+        from crimson.save_editor import parc_serializer as parc_serializer
         return parc_serializer, None
     except ImportError as e:
         return None, f"parc_serializer not available: {e}"
@@ -939,19 +939,230 @@ def _extract_bag_ranges(data: bytes | bytearray) -> List[Tuple[int, int, str]]:
     return bag_ranges
 
 
+def _item_from_child_fields(raw: bytes, child_fields, source: str, bag: str = ""):
+    start = None
+    offsets = {}
+    values = {}
+    for cf in child_fields:
+        if not cf.present:
+            continue
+        if start is None:
+            start = cf.start_offset
+        offsets[cf.name] = cf.start_offset
+        size = cf.end_offset - cf.start_offset
+        try:
+            if size == 1:
+                values[cf.name] = raw[cf.start_offset]
+            elif size == 2:
+                values[cf.name] = struct.unpack_from('<H', raw, cf.start_offset)[0]
+            elif size == 4:
+                values[cf.name] = struct.unpack_from('<I', raw, cf.start_offset)[0]
+            elif size == 8:
+                values[cf.name] = struct.unpack_from('<q', raw, cf.start_offset)[0]
+        except struct.error:
+            continue
+    if start is None or '_itemKey' not in values:
+        return None
+    # The editors write by fixed delta (_itemKey at +12, _stackCount at +18).
+    # Mercenary _equipItemList uses a different schema; surfacing those would
+    # let an edit land on the wrong bytes, so only emit editable records.
+    if offsets['_itemKey'] != start + 12:
+        return None
+    end = max(cf.end_offset for cf in child_fields if cf.present)
+    enchant = values.get('_enchantLevel', 0)
+    return SaveItem(
+        offset=start,
+        item_no=values.get('_itemNo', 0),
+        item_key=values.get('_itemKey', 0),
+        slot_no=values.get('_slotNo', 0),
+        stack_count=values.get('_stackCount', 0),
+        enchant_level=enchant,
+        endurance=values.get('_endurance', 0),
+        sharpness=values.get('_sharpness', 0),
+        has_enchant=enchant > 0,
+        is_equipment=(source == "Equipment"),
+        source=source,
+        bag=bag,
+        block_size=end - start,
+        field_offsets=offsets,
+        parc_parsed=True,
+    )
+
+
+# Owners that hold item records in nested per-entry lists. "Sold to Vendor"
+# matches the source name the Vendor tab filters on.
+_NESTED_ITEM_OWNERS = {
+    'MercenaryClanSaveData': ('_mercenaryDataList', 'Mercenary'),
+    'StoreSaveData': ('_storeDataList', 'Sold to Vendor'),
+}
+
+
+def scan_items_from_parse(
+    data: bytes | bytearray,
+    result,
+) -> Tuple[List[SaveItem], List[Tuple[int, int]]]:
+    """Extract items by walking the parsed save tree.
+
+    Every inventory container (`InventorySaveData._inventorylist[*]._itemList`)
+    and equipped piece (`EquipmentSaveData._list[*]._item`) is emitted with
+    exact per-field offsets. Records keep the classic fixed deltas (_itemNo at
+    +4, _itemKey at +12, _slotNo at +16, _stackCount at +18) so record-relative
+    editing code keeps working. Returns (items, covered_byte_spans).
+    """
+    raw = bytes(data)
+    items: List[SaveItem] = []
+    spans: List[Tuple[int, int]] = []
+    for obj in result['objects']:
+        if obj.class_name == 'InventorySaveData':
+            for f in obj.fields:
+                if f.name != '_inventorylist' or not f.list_elements:
+                    continue
+                for bag_elem in f.list_elements:
+                    if not bag_elem.child_fields:
+                        continue
+                    inv_key = -1
+                    for cf in bag_elem.child_fields:
+                        if cf.name == '_inventoryKey' and cf.present:
+                            try:
+                                inv_key = int(cf.value_repr or -1)
+                            except (ValueError, TypeError):
+                                inv_key = -1
+                    bag_name = (
+                        BAG_KEY_NAMES.get(inv_key, f"Bag_{inv_key}")
+                        if inv_key >= 0 else ""
+                    )
+                    for cf in bag_elem.child_fields:
+                        if cf.name == '_itemList' and cf.list_elements:
+                            spans.append((
+                                cf.list_elements[0].start_offset,
+                                cf.list_elements[-1].end_offset,
+                            ))
+                            for elem in cf.list_elements:
+                                if not elem.child_fields:
+                                    continue
+                                item = _item_from_child_fields(
+                                    raw, elem.child_fields, "Inventory", bag_name
+                                )
+                                if item:
+                                    items.append(item)
+        elif obj.class_name == 'EquipmentSaveData':
+            for f in obj.fields:
+                if f.name == '_list' and f.list_elements:
+                    spans.append((
+                        f.list_elements[0].start_offset,
+                        f.list_elements[-1].end_offset,
+                    ))
+                    for elem in f.list_elements:
+                        for cf in elem.child_fields or []:
+                            if cf.name == '_item' and cf.child_fields:
+                                item = _item_from_child_fields(
+                                    raw, cf.child_fields, "Equipment"
+                                )
+                                if item:
+                                    items.append(item)
+        elif obj.class_name in _NESTED_ITEM_OWNERS:
+            owner_list, source = _NESTED_ITEM_OWNERS[obj.class_name]
+            for f in obj.fields:
+                if f.name != owner_list or not f.list_elements:
+                    continue
+                for owner in f.list_elements:
+                    for cf in owner.child_fields or []:
+                        if not cf.list_elements or not cf.list_elements[0].child_fields:
+                            continue
+                        if not any(
+                            c.name == '_itemKey'
+                            for c in cf.list_elements[0].child_fields
+                        ):
+                            continue
+                        spans.append((
+                            cf.list_elements[0].start_offset,
+                            cf.list_elements[-1].end_offset,
+                        ))
+                        for elem in cf.list_elements:
+                            if not elem.child_fields:
+                                continue
+                            item = _item_from_child_fields(
+                                raw, elem.child_fields, source
+                            )
+                            if item:
+                                items.append(item)
+    return items, spans
+
+
+def scan_items_smart(data: bytes | bytearray, result=None) -> List[SaveItem]:
+    """Best-available item extraction: parse tree first, pattern scan to fill.
+
+    The pattern scanner recognizes records by byte signature and misses most
+    nested container items (32-77% coverage depending on save generation).
+    Inventory, equipment, mercenary, and vendor items all come from the tree;
+    legacy hits are kept only for sources the tree did not produce, and on any
+    parse failure the legacy result is returned unchanged.
+    """
+    legacy = scan_items(data)
+    if result is None:
+        try:
+            _ensure = 'Communitydump/desktopeditor'
+            if _ensure not in __import__('sys').path:
+                __import__('sys').path.insert(0, _ensure)
+            from save_parser import build_result_from_raw
+            result = build_result_from_raw(bytes(data), {'input_kind': 'raw_blob'})
+        except Exception:
+            return legacy
+    try:
+        parsed, spans = scan_items_from_parse(data, result)
+    except Exception:
+        return legacy
+    if not parsed:
+        return legacy
+
+    def _covered(offset: int) -> bool:
+        return any(start <= offset < end for start, end in spans)
+
+    # The parse tree is authoritative for the sources it actually produced;
+    # keeping legacy hits for those only re-adds pattern-scan false positives.
+    parsed_sources = {item.source for item in parsed}
+    merged = parsed + [
+        item for item in legacy
+        if not _covered(item.offset) and item.source not in parsed_sources
+    ]
+    merged.sort(key=lambda item: item.offset)
+    return merged
+
+
 def enrich_items_with_parc(
     data: bytes | bytearray,
     items: List[SaveItem],
+    progress_cb=None,
 ) -> Tuple[int, str]:
+    TOTAL_STEPS = 4
+
+    def _report(step: int) -> None:
+        if progress_cb:
+            progress_cb(step, TOTAL_STEPS)
+
+    # scan_items_smart already gives every item its exact field offsets and
+    # bag from the parse tree; re-deriving them here would run a second full
+    # parse (seconds) on whatever thread called us.
+    if items and all(item.parc_parsed and item.field_offsets for item in items):
+        _report(TOTAL_STEPS)
+        return len(items), (
+            f"PARC mode: {len(items)}/{len(items)} items enriched with exact "
+            "field offsets"
+        )
+
     parc_items, status = scan_items_parc(data)
+    _report(1)
     if not parc_items:
+        _report(TOTAL_STEPS)
         return 0, status
 
     parc_by_no: Dict[int, SaveItem] = {}
     for pi in parc_items:
         parc_by_no[pi.item_no] = pi
+    _report(2)
 
     bag_ranges = _extract_bag_ranges(data)
+    _report(3)
 
     enriched = 0
     for item in items:
@@ -966,6 +1177,7 @@ def enrich_items_with_parc(
                 item.bag = bname
                 break
 
+    _report(TOTAL_STEPS)
     return enriched, f"PARC mode: {enriched}/{len(items)} items enriched with exact field offsets"
 
 

--- a/CrimsonSaveEditor/parc_inserter3.py
+++ b/CrimsonSaveEditor/parc_inserter3.py
@@ -2438,10 +2438,19 @@ def inject_knowledge_fast(
         return False, blob, "KnowledgeSaveData._list not found"
 
     existing_keys = set()
+    level_offsets = {}
     for elem in know_field.list_elements:
+        key = level_off = level_val = None
         for cf in (elem.child_fields or []):
             if cf.name == '_key' and cf.present:
-                existing_keys.add(struct.unpack_from('<I', orig_blob, cf.start_offset)[0])
+                key = struct.unpack_from('<I', orig_blob, cf.start_offset)[0]
+            elif cf.name == '_level' and cf.present:
+                level_off = cf.start_offset
+                level_val = struct.unpack_from('<I', orig_blob, cf.start_offset)[0]
+        if key is not None:
+            existing_keys.add(key)
+            if level_off is not None and level_val == 0:
+                level_offsets[key] = level_off
 
     if keys_filter is not None:
         target_keys = set(keys_filter)
@@ -2451,8 +2460,17 @@ def inject_knowledge_fast(
             return False, blob, "knowledge_keys_all.json not found"
         target_keys = set(all_keys)
 
+    # An entry can exist at level 0 - exactly what Unlearn leaves behind -
+    # and the game treats it as unlearned. Treating key-presence as
+    # "already learned" made re-learning those a silent no-op.
+    relearn = sorted(k for k in target_keys if k in level_offsets)
+    for key in relearn:
+        struct.pack_into('<I', blob, level_offsets[key], 1)
+
     to_insert = sorted(target_keys - existing_keys)
     if not to_insert:
+        if relearn:
+            return True, blob, f"Re-learned {len(relearn)} existing entries"
         return True, blob, "All requested knowledge already present"
 
     t1 = time.time()
@@ -2657,10 +2675,19 @@ def inject_all_knowledge(
         return False, blob, "KnowledgeSaveData._list not found"
 
     existing_keys = set()
+    level_offsets = {}
     for elem in know_field.list_elements:
+        key = level_off = level_val = None
         for cf in (elem.child_fields or []):
             if cf.name == '_key' and cf.present:
-                existing_keys.add(struct.unpack_from('<I', orig_blob, cf.start_offset)[0])
+                key = struct.unpack_from('<I', orig_blob, cf.start_offset)[0]
+            elif cf.name == '_level' and cf.present:
+                level_off = cf.start_offset
+                level_val = struct.unpack_from('<I', orig_blob, cf.start_offset)[0]
+        if key is not None:
+            existing_keys.add(key)
+            if level_off is not None and level_val == 0:
+                level_offsets[key] = level_off
 
     if keys_filter is not None:
         target_keys = set(keys_filter)
@@ -2670,8 +2697,17 @@ def inject_all_knowledge(
             return False, blob, "knowledge_keys_all.json not found"
         target_keys = set(all_keys)
 
+    # An entry can exist at level 0 - exactly what Unlearn leaves behind -
+    # and the game treats it as unlearned. Treating key-presence as
+    # "already learned" made re-learning those a silent no-op.
+    relearn = sorted(k for k in target_keys if k in level_offsets)
+    for key in relearn:
+        struct.pack_into('<I', blob, level_offsets[key], 1)
+
     to_insert = sorted(target_keys - existing_keys)
     if not to_insert:
+        if relearn:
+            return True, blob, f"Re-learned {len(relearn)} existing entries"
         return True, blob, "All requested knowledge already present"
 
     return _insert_knowledge_keys(blob, orig_blob, know_obj, know_field, to_insert, len(existing_keys))

--- a/CrimsonSaveEditor/parse_reuse.py
+++ b/CrimsonSaveEditor/parse_reuse.py
@@ -1,0 +1,103 @@
+"""Reuse expensive parses across GUI handlers.
+
+``build_result_from_raw`` fully decodes the 6.4 MB save blob (~5 s). The
+result only carries structure — object/field offsets into the blob — while
+every consumer re-reads values from the current bytes at those offsets. One
+parse therefore stays valid until ``SaveData.decompressed_blob`` is wholesale
+replaced; ``SaveData.__setattr__`` bumps ``parse_epoch`` on every replacement
+(see models.py), which is the cache invalidation signal used here.
+
+``game_map.json`` is ~22 MB of static game data; it is parsed once per process
+into small name lookup tables.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from typing import Any, Optional
+
+
+class ParsedResultCache:
+    """Hold the last full parse for exactly one SaveData generation.
+
+    Keyed by SaveData identity plus its ``parse_epoch``; in-place byte edits
+    keep the entry (offsets stay valid), replacing the blob evicts it. Holds a
+    strong reference to the SaveData so id-reuse can never alias a new save
+    onto a stale parse.
+    """
+
+    def __init__(self) -> None:
+        self._save_ref: Any = None
+        self._epoch: int = -1
+        self._result: Any = None
+
+    def get(self, save_data) -> Optional[Any]:
+        if save_data is None:
+            return None
+        if (
+            self._save_ref is save_data
+            and self._epoch == getattr(save_data, "parse_epoch", 0)
+        ):
+            return self._result
+        return None
+
+    def store(self, save_data, result) -> None:
+        if save_data is None or result is None:
+            return
+        self._save_ref = save_data
+        self._epoch = getattr(save_data, "parse_epoch", 0)
+        self._result = result
+
+    def clear(self) -> None:
+        self._save_ref = None
+        self._epoch = -1
+        self._result = None
+
+
+_GAME_MAP_LOCK = threading.Lock()
+_GAME_MAP_NAMES: Optional[dict] = None
+
+
+def load_game_map_names() -> dict:
+    """Parse game_map.json once and return small int->name lookup tables."""
+    global _GAME_MAP_NAMES
+    cached = _GAME_MAP_NAMES
+    if cached is not None:
+        return cached
+    with _GAME_MAP_LOCK:
+        if _GAME_MAP_NAMES is not None:
+            return _GAME_MAP_NAMES
+        names = {
+            'factions': {},
+            'factionnodes': {},
+            'characters': {},
+            'sublevels': {},
+        }
+        try:
+            base = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+            gm_path = os.path.join(base, 'game_map.json')
+            if os.path.isfile(gm_path):
+                with open(gm_path, 'r', encoding='utf-8') as f:
+                    gm = json.load(f)
+                for k, v in gm.get('factions', {}).items():
+                    if isinstance(v, dict):
+                        names['factions'][int(k)] = v.get('name', '')
+                for k, v in gm.get('factionnodes', {}).items():
+                    if isinstance(v, dict):
+                        names['factionnodes'][int(k)] = v.get('name', '')
+                for k, v in gm.get('characters', {}).items():
+                    if isinstance(v, dict):
+                        names['characters'][int(k)] = v.get('name', '')
+                    elif isinstance(v, str):
+                        names['characters'][int(k)] = v
+                for k, v in gm.get('sublevels', {}).items():
+                    if isinstance(v, dict):
+                        names['sublevels'][int(k)] = v.get('name', f'SubLevel_{k}')
+                    else:
+                        names['sublevels'][int(k)] = str(v)
+        except Exception:
+            pass
+        _GAME_MAP_NAMES = names
+        return names


### PR DESCRIPTION
Third PR from #96. **Stacked on #98** (uses its cached parse; merging #98 first makes this diff small).

Three related Knowledge defects that hide each other:

1. **Learn can silently do nothing.** The injector treats *key presence* as already-learned — but an entry can exist at **level 0**, which is exactly what Unlearn leaves behind. Learning it pops a success dialog, marks the row learned, and writes nothing. Both inject paths now re-learn present-at-level-0 keys in place, and the table refreshes after injection.
2. **The learned-scan misclassifies.** It walks the block at a 4-byte stride, so unaligned keys are missed (shown unlearned when present) and stray level-0 words in range count as learned. Replaced with an exact walk of the parse tree: learned = present at level ≥ 1.
3. **Unlearn can crash with a buffer overrun** — its raw scan unpacks 8 bytes at `i+8` while iterating to `len-14`, reading past the block tail (`unpack_from requires a buffer of at least N bytes`). It now patches the level field through the parse tree; the debug scanner keeps its raw walk with the bound corrected to `len-15`.

**Verified** on a real 1.15 save: 4,151 entries scanned exactly; unlearn zeroes the level in place; re-injecting the same key reports `Re-learned 1 existing entries` and writes level 1 back — the previously-silent path now does real work.