### PR TITLE
Quest editor: rows sharing a key are quests vs missions, not duplicates (#46)

### DIFF
--- a/CrimsonSaveEditor/gui.py
+++ b/CrimsonSaveEditor/gui.py
@@ -1136,7 +1136,10 @@ class QuestEditorWindow(QDialog):
                             entry['state_name'] = self.QUEST_STATE_NAMES.get(entry['state'], f'0x{entry["state"]:02X}')
                             entry['state_raw'] = entry['state']
                             entry['display'] = entry['name']
-                            chain = self._quest_chains.get(entry['key'])
+                            # Quest chains are keyed by quest keys; missions
+                            # number independently, so looking one up here
+                            # attaches an unrelated quest's chain.
+                            chain = None
                             entry['chain'] = chain
                             self._mission_entries.append(entry)
                 break
@@ -10539,23 +10542,24 @@ QCheckBox::indicator {{
             state_sz = entry.get('state_size', 4)
             mask_hex = entry.get('mask_hex', '')
 
+            kind_label = "Mission" if is_mission else "Quest"
             if has_ct:
-                type_str = "OK"
+                type_str = kind_label
                 type_color = COLORS['success']
-                tip = f"{'Mission' if is_mission else 'Quest'} | Has _completedTime | State: {state_sz}B | Mask: {mask_hex}"
+                tip = f"{kind_label} | Has _completedTime | State: {state_sz}B | Mask: {mask_hex}"
             elif needs_expand and is_mission:
-                type_str = "PARC"
+                type_str = f"{kind_label} · PARC"
                 type_color = COLORS['warning']
                 tip = (f"Mission | No _completedTime — needs PARC expansion to complete\n"
                        f"State: {state_sz}B | Mask: {mask_hex}\n"
                        f"Mark Completed will auto-insert timestamp fields")
             elif needs_expand:
-                type_str = "PARC"
+                type_str = f"{kind_label} · PARC"
                 type_color = COLORS['warning']
                 tip = (f"Quest | No _completedTime — may need PARC expansion\n"
                        f"State: {state_sz}B | Mask: {mask_hex}")
             else:
-                type_str = "OK"
+                type_str = kind_label
                 type_color = COLORS['text']
                 tip = f"{'Mission' if is_mission else 'Quest'} | State: {state_sz}B | Mask: {mask_hex}"
 


### PR DESCRIPTION
Fixes #46 ("What's the cause of duplicate entries?"), open since April.

**Cause** — quests and missions number their keys in *independent namespaces*. On the save I tested, **891 of 898 quest keys also exist as mission keys**:

| key | as a quest | as a mission |
|---|---|---|
| 1000000 | Quest_Node_Dem_TheLaughingMarionette_Circus_Normal | Mission_Marni_Mine_Fortress_Airplane_Boss_Start |
| 1000001 | Quest_Node_Her_RuinedChapel_Block | Mission_FlowerDustBeeFarm_Normal_Start |

The editor lists `_quest_entries + _mission_entries` together, so those become two rows with the same key and two unrelated names — 6,745 rows for 5,901 distinct keys on my test save. Nothing is wrong with the save.

**Fix 1 — make the rows readable.** Each entry already carries `is_mission`, but it only appeared in a tooltip while the visible **Type** column showed PARC status. Type now leads with `Quest` / `Mission` and appends ` · PARC` where expansion is needed, so both signals survive and a key's two rows are visibly different records.

**Fix 2 — stop chains cross-matching.** Missions looked up `self._quest_chains.get(entry['key'])` with a bare key. Chains are keyed by *quest* keys, so with 891 keys overlapping, a mission would inherit an unrelated quest's chain for most chained quests. Missions no longer consult that table.

If missions are meant to have chains of their own, that wants a mission-keyed table rather than reusing the quest one — happy to adjust.